### PR TITLE
Refactor: Remove unused `Any` import in ai_content_generator.py

### DIFF
--- a/src/blank_business_builder/features/ai_content_generator.py
+++ b/src/blank_business_builder/features/ai_content_generator.py
@@ -5,7 +5,7 @@ Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights
 Reverse-engineered and improved from Jasper AI + Copy.ai + Writesonic
 Adds quantum optimization and Level-6-Agent capabilities they don't have.
 """
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional
 from datetime import datetime
 from dataclasses import dataclass
 from enum import Enum
@@ -52,7 +52,7 @@ class ContentRequest:
     length: str  # short, medium, long
     keywords: List[str]
     target_audience: str
-    brand_voice: Optional[Dict[str, Any]] = None
+    brand_voice: Optional[Dict] = None
     ai_model: AIModel = AIModel.GPT4_TURBO
     seo_optimize: bool = True
     include_images: bool = False


### PR DESCRIPTION
Removed `Any` from `src/blank_business_builder/features/ai_content_generator.py` imports and usage to improve code readability and remove unnecessary dependency on `Any`.

- Replaced `brand_voice: Optional[Dict[str, Any]]` with `brand_voice: Optional[Dict]`
- Removed `Any` from `from typing import ...` list.
- Verified that the module imports correctly and type hints are valid.

---
*PR created automatically by Jules for task [2347490058661440111](https://jules.google.com/task/2347490058661440111) started by @Workofarttattoo*