### PR TITLE
🧹 Remove unused import JSONResponse

### DIFF
--- a/src/blank_business_builder/main.py
+++ b/src/blank_business_builder/main.py
@@ -4,7 +4,7 @@ Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights
 """
 from fastapi import FastAPI, Depends, HTTPException, status, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, FileResponse
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from datetime import datetime, timedelta


### PR DESCRIPTION
Removed the unused import `JSONResponse` from `src/blank_business_builder/main.py` to improve code readability and maintainability.

Verified the changes by running `pytest tests/test_businesses.py`. The existing test failure in `test_list_businesses` persists (due to free tier limits) and is unrelated to this change. Other tests passed.

---
*PR created automatically by Jules for task [16982654075254450050](https://jules.google.com/task/16982654075254450050) started by @Workofarttattoo*