### PR TITLE
Clean up unused import in `src/blank_business_builder/main.py`

### DIFF
--- a/src/blank_business_builder/main.py
+++ b/src/blank_business_builder/main.py
@@ -27,12 +27,10 @@ from .integrations import IntegrationFactory
 from .self_healing import build_self_healing_orchestrator, self_healing_enabled
 from pydantic import BaseModel
 try:
-    from pydantic import EmailStr as _EmailStr  # type: ignore
-    from pydantic.networks import import_email_validator  # type: ignore
-    import_email_validator()
-    EmailStr = _EmailStr
-except Exception:  # pragma: no cover
-    EmailStr = str  # type: ignore
+    import email_validator  # noqa: F401
+    from pydantic import EmailStr
+except ImportError:
+    EmailStr = str
 
 # Initialize FastAPI app
 app = FastAPI(


### PR DESCRIPTION
Replaced the usage of `pydantic.networks.import_email_validator` with a direct `import email_validator` check.

This change:
- Resolves the "Unused Import" issue flagged by static analysis.
- Simplifies the dependency check logic.
- Maintains the existing behavior where `EmailStr` falls back to `str` if `email-validator` is not installed.
- Verified using a reproduction script that asserts correct type assignment.

---
*PR created automatically by Jules for task [13211188915714980234](https://jules.google.com/task/13211188915714980234) started by @Workofarttattoo*