### PR TITLE
🧪 Add tests for VoiceAssistant

### DIFF
--- a/tests/test_voice_assistant.py
+++ b/tests/test_voice_assistant.py
@@ -1,0 +1,48 @@
+import pytest
+import asyncio
+from src.blank_business_builder.all_features_implementation import VoiceAssistant, VoiceCommand
+
+class TestVoiceAssistant:
+    """Tests for the VoiceAssistant class."""
+
+    @pytest.mark.asyncio
+    async def test_process_voice_command_get_metrics(self):
+        """Test that process_voice_command returns metrics (default behavior)."""
+        assistant = VoiceAssistant()
+        # Input audio data is ignored in the current implementation
+        result = await assistant.process_voice_command("dummy audio data")
+
+        assert "response" in result
+        assert "Your revenue this month is $125,000" in result["response"]
+        assert "data" in result
+        assert result["data"]["revenue"] == 125000
+        assert result["data"]["users"] == 450
+
+    @pytest.mark.asyncio
+    async def test_execute_command_get_metrics(self):
+        """Test _execute_command explicitly with GET_METRICS."""
+        assistant = VoiceAssistant()
+        result = await assistant._execute_command(VoiceCommand.GET_METRICS, {})
+
+        assert "response" in result
+        assert "Your revenue this month is $125,000" in result["response"]
+        assert "data" in result
+        assert result["data"]["revenue"] == 125000
+        assert result["data"]["users"] == 450
+
+    @pytest.mark.asyncio
+    async def test_execute_command_other(self):
+        """Test _execute_command with other commands."""
+        assistant = VoiceAssistant()
+
+        # Test CREATE_CAMPAIGN
+        result = await assistant._execute_command(VoiceCommand.CREATE_CAMPAIGN, {})
+        assert result == {"response": "Command executed successfully"}
+
+        # Test SCHEDULE_MEETING
+        result = await assistant._execute_command(VoiceCommand.SCHEDULE_MEETING, {})
+        assert result == {"response": "Command executed successfully"}
+
+        # Test SEND_EMAIL
+        result = await assistant._execute_command(VoiceCommand.SEND_EMAIL, {})
+        assert result == {"response": "Command executed successfully"}


### PR DESCRIPTION
Added comprehensive unit tests for the `VoiceAssistant` class in `src/blank_business_builder/all_features_implementation.py`.

The new tests cover:
1.  `process_voice_command`: Verifies the public API returns the correct structure and data for the default `GET_METRICS` command.
2.  `_execute_command`:
    *   Verifies explicit `GET_METRICS` command execution.
    *   Verifies fallback behavior for other commands (`CREATE_CAMPAIGN`, `SCHEDULE_MEETING`, `SEND_EMAIL`).

This improves test coverage for the voice assistant feature. Note that the existing test suite has some unrelated failures due to environment issues, but the new tests pass reliably.

---
*PR created automatically by Jules for task [14421236788917571278](https://jules.google.com/task/14421236788917571278) started by @Workofarttattoo*