### PR TITLE
⚡ Optimize priority calculation in qulab_rental_business

### DIFF
--- a/src/blank_business_builder/qulab_rental_business.py
+++ b/src/blank_business_builder/qulab_rental_business.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Dict, List, Optional, Any
 from decimal import Decimal
+from collections import Counter
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +31,24 @@ class RentalPackage(Enum):
     FULL_WEEK = "full_week"    # 7 days - $5,000
 
 
+class SubscriptionTier(Enum):
+    """Subscription tiers."""
+    RESEARCH = "research"
+    STARTUP = "startup"
+    PROFESSIONAL = "professional"
+    ENTERPRISE = "enterprise"
+    DEDICATED = "dedicated"
+
+
 class JobPriority(Enum):
     """Job queue priority levels."""
     STANDARD = "standard"      # Standard queue
     EXPRESS = "express"        # Priority processing (+50%)
     DEDICATED = "dedicated"    # Exclusive time slot (+100%)
+    LOW = "low"
+    NORMAL = "normal"
+    HIGH = "high"
+    URGENT = "urgent"
 
 
 @dataclass
@@ -407,10 +421,9 @@ class QuLabRentalBusiness:
             "usage_breakdown": {
                 "avg_qubits_per_job": sum(j.num_qubits for j in completed_jobs) / max(1, len(completed_jobs)),
                 "total_simulation_minutes": sum(j.simulation_minutes for j in completed_jobs),
-                "most_used_priority": max(
-                    [j.priority.value for j in customer_jobs],
-                    key=[j.priority.value for j in customer_jobs].count
-                ) if customer_jobs else "none"
+                "most_used_priority": Counter(
+                    j.priority.value for j in customer_jobs
+                ).most_common(1)[0][0] if customer_jobs else "none"
             },
             "recommendations": self._generate_recommendations(customer)
         }


### PR DESCRIPTION
Optimized the `most_used_priority` calculation in `src/blank_business_builder/qulab_rental_business.py` to use `collections.Counter` instead of `max(list, key=list.count)`. This changes the time complexity from O(N^2) to O(N).

Also fixed critical code health issues in the same file:
- Added missing `SubscriptionTier` Enum definition.
- Updated `JobPriority` Enum to include missing values (LOW, NORMAL, HIGH, URGENT) used by the code, while preserving existing values (STANDARD, EXPRESS).

Verified functionality using the built-in `demo_qulab_rental` async function.

---
*PR created automatically by Jules for task [17776723648782276213](https://jules.google.com/task/17776723648782276213) started by @Workofarttattoo*