### PR TITLE
🔒 Security: Disable uvicorn reload in production and clean up dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,7 @@ dependencies = [
     "tweepy>=4.14.0",
 
     # Web Scraping & Automation
-    "selenium>=4.16.0",
-    "webdriver-manager>=4.0.1",
-    "scrapingbee>=2.2.0",
+    "scrapingbee>=2.0.0",
 
     # Data Processing
     "numpy>=1.26.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ redis==5.0.1
 # Authentication
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+bcrypt==3.2.2  # Required for passlib compatibility
 python-dotenv==1.0.0
 
 # Payment Processing
@@ -51,15 +52,10 @@ cryptography==42.0.0
 pydantic==2.5.3
 pydantic-settings==2.1.0
 
-# Fiverr Autonomous Manager
-selenium==4.16.0
-webdriver-manager==4.0.1
-
 # Quantum Features Dependencies
 numpy==1.26.4
 scipy==1.13.0
 scikit-learn==1.4.2
-gzip  # Built-in Python library
 
 # Development
 black==24.1.1
@@ -70,7 +66,7 @@ bandit==1.7.5
 safety==2.3.5
 
 rich==13.7.1
-scrapingbee==2.2.0
+scrapingbee==2.0.2
 starkbank-ecdsa==2.3.0
 streamlit==1.33.0
 tenacity==8.2.3

--- a/src/blank_business_builder/main.py
+++ b/src/blank_business_builder/main.py
@@ -659,9 +659,17 @@ async def activate_license(
 # Run application
 if __name__ == "__main__":
     import os
+
+    # Secure defaults: debug mode disabled, environment is production
+    debug_mode = os.getenv("DEBUG", "false").lower() == "true"
+    environment = os.getenv("ENVIRONMENT", "production").lower()
+
+    # Only enable reload in development environment
+    should_reload = debug_mode or environment == "development"
+
     uvicorn.run(
         "main:app",
         host="0.0.0.0",
         port=int(os.getenv("PORT", 8000)),
-        reload=True
+        reload=should_reload
     )


### PR DESCRIPTION
This PR addresses a security vulnerability where `uvicorn` was running with `reload=True` in production, exposing the debugger and potentially sensitive information.

**Security Fix:**
- Updated `src/blank_business_builder/main.py` to conditionally enable reload. It now defaults to `False` (secure) unless `ENVIRONMENT` is set to `development` or `DEBUG` is set to `true`.

**Dependency Cleanup:**
- Removed `selenium` and `webdriver-manager` from `requirements.txt` and `pyproject.toml` as they are unused in the codebase (verified via grep) and were flagged for removal in project memory.
- Downgraded `scrapingbee` to version `2.0.2` because version `2.2.0` specified in `requirements.txt` was not available in the package index, causing installation failures.
- Pinned `bcrypt==3.2.2` to resolve incompatibility with `passlib==1.7.4`.

**Verification:**
- Verified the fix using a reproduction script that checks if the server starts with reload enabled/disabled under different environment configurations.
- Ran the test suite (`pytest`) to ensure no regressions were introduced by these changes. Pre-existing test failures were confirmed to be unrelated to this patch.


---
*PR created automatically by Jules for task [9827345901706817412](https://jules.google.com/task/9827345901706817412) started by @Workofarttattoo*