### PR TITLE
🔒 Fix weak password hashing vulnerability in auth.py

### DIFF
--- a/src/blank_business_builder/auth.py
+++ b/src/blank_business_builder/auth.py
@@ -52,15 +52,7 @@ else:  # pragma: no cover - exercised when passlib is unavailable
 
         @staticmethod
         def verify(plain_password: str, hashed_password: str) -> bool:
-            """Verify a password against a hash (supports legacy SHA-256 fallback)."""
-            # Check for legacy SHA-256 format (64 hex characters)
-            if len(hashed_password) == 64 and all(c in '0123456789abcdef' for c in hashed_password):
-                # Legacy verification (VULNERABLE - for backward compatibility only)
-                return compare_digest(
-                    hashlib.sha256(plain_password.encode("utf-8")).hexdigest(),
-                    hashed_password
-                )
-
+            """Verify a password against a hash."""
             try:
                 # Parse secure format: algo$iterations$salt$hash
                 parts = hashed_password.split('$')

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -1,0 +1,38 @@
+import pytest
+import hashlib
+from blank_business_builder.auth import _SimpleCryptContext, AuthService
+
+class TestAuthSecurity:
+    """Security specific tests for authentication."""
+
+    def test_legacy_sha256_vulnerability_fixed(self):
+        """Ensure that legacy unsalted SHA-256 hashes are NO LONGER accepted."""
+        password = "password123"
+        # Create a legacy unsalted SHA-256 hash
+        legacy_hash = hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+        # Verify it using the method directly
+        # It should return False now (after fix)
+        # Before fix, this would return True
+        assert not _SimpleCryptContext.verify(password, legacy_hash), \
+            "Vulnerability still exists: Legacy unsalted SHA-256 hash was accepted."
+
+    def test_secure_hashing_still_works(self):
+        """Ensure that the secure hashing mechanism still works."""
+        password = "secure_password"
+        hashed = _SimpleCryptContext.hash(password)
+
+        # It should be a secure hash (pbkdf2_sha256)
+        assert hashed.startswith("pbkdf2_sha256$")
+
+        # Verify should return True
+        assert _SimpleCryptContext.verify(password, hashed)
+
+        # Verify with wrong password should return False
+        assert not _SimpleCryptContext.verify("wrong_password", hashed)
+
+    def test_auth_service_hashing(self):
+        """Ensure AuthService uses the context correctly."""
+        password = "my_password"
+        hashed = AuthService.hash_password(password)
+        assert AuthService.verify_password(password, hashed)


### PR DESCRIPTION
This PR fixes a security vulnerability in `src/blank_business_builder/auth.py` where the `_SimpleCryptContext` fallback class allowed verification of unsalted SHA-256 hashes.

**Changes:**
- Removed the code block in `_SimpleCryptContext.verify` that checked for and verified legacy SHA-256 hashes.
- Added a new test file `tests/test_auth_security.py` which:
    - Confirms that legacy unsalted SHA-256 hashes are now rejected.
    - Confirms that the secure PBKDF2-HMAC-SHA256 hashing still works correctly.

**Testing:**
- Verified with `tests/test_auth_security.py` (all passed).
- Ran existing `tests/test_auth.py` to ensure no regressions (existing unrelated failures persist).


---
*PR created automatically by Jules for task [3161237317671181261](https://jules.google.com/task/3161237317671181261) started by @Workofarttattoo*