### PR TITLE
Add tests for External Integrations (OpenAI, SendGrid, Buffer)

### DIFF
--- a/tests/test_anthropic_service.py
+++ b/tests/test_anthropic_service.py
@@ -4,6 +4,7 @@ Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights
 """
 import pytest
 import sys
+import importlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -16,25 +17,30 @@ sys.modules["anthropic"] = MagicMock() # Mock anthropic to ensure we test the se
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-# Now import the module under test
-from blank_business_builder.integrations import AnthropicService, IntegrationFactory
+from blank_business_builder import integrations
 
 class TestAnthropicService:
     """Test AnthropicService functionality."""
 
+    def setup_method(self):
+        # Reload module to ensure we use current mocks/classes
+        importlib.reload(integrations)
+        self.AnthropicService = integrations.AnthropicService
+        self.IntegrationFactory = integrations.IntegrationFactory
+
     def test_initialization(self):
         """Test that AnthropicService initializes correctly."""
-        service = AnthropicService()
+        service = self.AnthropicService()
         assert hasattr(service, "generate_content")
 
     def test_factory_method(self):
         """Test that IntegrationFactory returns an AnthropicService instance."""
-        service = IntegrationFactory.get_anthropic_service()
-        assert isinstance(service, AnthropicService)
+        service = self.IntegrationFactory.get_anthropic_service()
+        assert isinstance(service, self.AnthropicService)
 
     def test_generate_content_mock(self):
         """Test generate_content with mocked client."""
-        service = AnthropicService()
+        service = self.AnthropicService()
         # Mock the client
         service.client = MagicMock()
         service.client.messages.create.return_value.content = [MagicMock(text="Mocked response")]
@@ -45,7 +51,7 @@ class TestAnthropicService:
     def test_generate_content_fallback(self):
         """Test generate_content fallback behavior."""
         # If client raises error
-        service = AnthropicService()
+        service = self.AnthropicService()
         service.client = MagicMock()
         service.client.messages.create.side_effect = Exception("Authentication error: api_key invalid")
 

--- a/tests/test_buffer_service.py
+++ b/tests/test_buffer_service.py
@@ -1,0 +1,130 @@
+"""
+Tests for BufferService Integration
+Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights Reserved. PATENT PENDING.
+"""
+import pytest
+import sys
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Mock dependencies for initial import
+sys.modules["requests"] = MagicMock()
+sys.modules["fastapi"] = MagicMock()
+sys.modules["fastapi.status"] = MagicMock()
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from blank_business_builder import integrations
+
+class TestBufferService:
+    """Test BufferService functionality."""
+
+    def setup_method(self):
+        # Mock dependencies
+        self.mock_requests = MagicMock()
+        sys.modules["requests"] = self.mock_requests
+
+        # Mock FastAPI
+        class MockHTTPException(Exception):
+            def __init__(self, status_code, detail):
+                self.status_code = status_code
+                self.detail = detail
+
+        mock_fastapi = MagicMock()
+        mock_fastapi.HTTPException = MockHTTPException
+        mock_fastapi.status = MagicMock()
+        mock_fastapi.status.HTTP_501_NOT_IMPLEMENTED = 501
+        mock_fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR = 500
+        sys.modules["fastapi"] = mock_fastapi
+        sys.modules["fastapi.status"] = mock_fastapi.status
+
+        # Reload module
+        importlib.reload(integrations)
+        self.BufferService = integrations.BufferService
+        self.IntegrationFactory = integrations.IntegrationFactory
+        self.MockHTTPException = MockHTTPException
+
+    def test_initialization(self):
+        """Test initialization with and without API key."""
+        with patch.dict('os.environ', {'BUFFER_ACCESS_TOKEN': 'test_token'}):
+            service = self.BufferService()
+            assert service.access_token == 'test_token'
+
+    def test_get_profiles_success(self):
+        """Test getting profiles successfully."""
+        with patch.dict('os.environ', {'BUFFER_ACCESS_TOKEN': 'test_token'}):
+            service = self.BufferService()
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = [{"id": "p1"}]
+            self.mock_requests.get.return_value = mock_response
+
+            profiles = service.get_profiles()
+
+            assert profiles == [{"id": "p1"}]
+            self.mock_requests.get.assert_called_once()
+            kwargs = self.mock_requests.get.call_args[1]
+            assert kwargs['params']['access_token'] == 'test_token'
+
+    def test_get_profiles_not_configured(self):
+        """Test getting profiles when not configured."""
+        with patch.dict('os.environ', {}, clear=True):
+            service = self.BufferService()
+
+            with pytest.raises(self.MockHTTPException) as excinfo:
+                service.get_profiles()
+
+            assert excinfo.value.status_code == 501
+            assert "not configured" in excinfo.value.detail
+
+    def test_get_profiles_failure(self):
+        """Test getting profiles failure."""
+        with patch.dict('os.environ', {'BUFFER_ACCESS_TOKEN': 'test_token'}):
+            service = self.BufferService()
+
+            self.mock_requests.get.side_effect = Exception("Buffer API Error")
+
+            with pytest.raises(self.MockHTTPException) as excinfo:
+                service.get_profiles()
+
+            assert excinfo.value.status_code == 500
+            assert "Buffer API Error" in excinfo.value.detail
+
+    def test_create_post_success(self):
+        """Test creating a post successfully."""
+        with patch.dict('os.environ', {'BUFFER_ACCESS_TOKEN': 'test_token'}):
+            service = self.BufferService()
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"success": True}
+            self.mock_requests.post.return_value = mock_response
+
+            result = service.create_post("p1", "Hello World")
+
+            assert result == {"success": True}
+            self.mock_requests.post.assert_called_once()
+
+    def test_schedule_post(self):
+        """Test scheduling a post."""
+        with patch.dict('os.environ', {'BUFFER_ACCESS_TOKEN': 'test_token'}):
+            service = self.BufferService()
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"success": True}
+            self.mock_requests.post.return_value = mock_response
+
+            result = service.schedule_post(
+                "p1", "Hello Future", 1234567890, "http://image.com"
+            )
+
+            assert result == {"success": True}
+            self.mock_requests.post.assert_called_once()
+            kwargs = self.mock_requests.post.call_args[1]
+            assert kwargs['data']['scheduled_at'] == 1234567890
+
+    def test_factory_method(self):
+        """Test IntegrationFactory creates BufferService."""
+        service = self.IntegrationFactory.get_buffer_service()
+        assert isinstance(service, self.BufferService)

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,0 +1,189 @@
+"""
+Tests for OpenAIService Integration
+Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights Reserved. PATENT PENDING.
+"""
+import pytest
+import sys
+import json
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Mock dependencies for initial import
+sys.modules["openai"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+sys.modules["fastapi"] = MagicMock()
+sys.modules["fastapi.status"] = MagicMock()
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from blank_business_builder import integrations
+
+class TestOpenAIService:
+    """Test OpenAIService functionality."""
+
+    def setup_method(self):
+        # Mock dependencies
+        self.mock_openai = MagicMock()
+        sys.modules["openai"] = self.mock_openai
+        sys.modules["requests"] = MagicMock()
+
+        # Mock FastAPI
+        class MockHTTPException(Exception):
+            def __init__(self, status_code, detail):
+                self.status_code = status_code
+                self.detail = detail
+
+        mock_fastapi = MagicMock()
+        mock_fastapi.HTTPException = MockHTTPException
+        mock_fastapi.status = MagicMock()
+        mock_fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR = 500
+        sys.modules["fastapi"] = mock_fastapi
+        sys.modules["fastapi.status"] = mock_fastapi.status
+
+        # Reload module to ensure it uses our mocks
+        importlib.reload(integrations)
+        self.OpenAIService = integrations.OpenAIService
+        self.IntegrationFactory = integrations.IntegrationFactory
+        self.MockHTTPException = MockHTTPException
+
+        # Setup OpenAI mock details
+        self.mock_openai.ChatCompletion = MagicMock()
+
+    def test_initialization(self):
+        """Test that OpenAIService initializes correctly."""
+        with patch.dict('os.environ', {'OPENAI_API_KEY': 'test-key', 'OPENAI_MODEL': 'gpt-4-test'}):
+            service = self.OpenAIService()
+            assert service.api_key == 'test-key'
+            assert service.model == 'gpt-4-test'
+            assert self.mock_openai.api_key == 'test-key'
+
+    def test_generate_business_plan_success(self):
+        """Test generating a business plan successfully."""
+        service = self.OpenAIService()
+
+        # Mock successful response
+        expected_plan = {
+            "executive_summary": "Summary",
+            "market_analysis": "Analysis",
+            "marketing_strategy": "Strategy",
+            "financial_projections": "Projections",
+            "operations_plan": "Plan"
+        }
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(expected_plan)
+
+        self.mock_openai.ChatCompletion.create.return_value = mock_response
+
+        plan = service.generate_business_plan(
+            "Test Biz", "Tech", "A test business"
+        )
+
+        assert plan == expected_plan
+        self.mock_openai.ChatCompletion.create.assert_called_once()
+
+        # Verify call arguments contain correct prompts
+        call_args = self.mock_openai.ChatCompletion.create.call_args
+        assert call_args.kwargs['model'] == service.model
+        assert "Test Biz" in call_args.kwargs['messages'][1]['content']
+
+    def test_generate_business_plan_json_error(self):
+        """Test generating a business plan with invalid JSON response."""
+        service = self.OpenAIService()
+
+        # Mock invalid JSON response
+        raw_content = "Not a JSON object"
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = raw_content
+
+        self.mock_openai.ChatCompletion.create.return_value = mock_response
+
+        plan = service.generate_business_plan(
+            "Test Biz", "Tech", "A test business"
+        )
+
+        assert plan == {"raw_content": raw_content}
+
+    def test_generate_business_plan_api_error(self):
+        """Test API error handling."""
+        service = self.OpenAIService()
+
+        # Mock API error
+        self.mock_openai.ChatCompletion.create.side_effect = Exception("API Error")
+
+        with pytest.raises(self.MockHTTPException) as excinfo:
+            service.generate_business_plan("Test Biz", "Tech", "Desc")
+
+        assert excinfo.value.status_code == 500
+        assert "API Error" in excinfo.value.detail
+
+    def test_generate_marketing_copy(self):
+        """Test generating marketing copy."""
+        service = self.OpenAIService()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Buy now!"
+
+        self.mock_openai.ChatCompletion.create.return_value = mock_response
+
+        copy = service.generate_marketing_copy(
+            "Test Biz", "Twitter", "Sales", "Everyone"
+        )
+
+        assert copy == "Buy now!"
+        self.mock_openai.ChatCompletion.create.assert_called_once()
+
+    def test_generate_email_campaign(self):
+        """Test generating email campaign."""
+        service = self.OpenAIService()
+
+        expected_email = {
+            "subject": "Hello",
+            "body": "World",
+            "cta": "Click"
+        }
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(expected_email)
+
+        self.mock_openai.ChatCompletion.create.return_value = mock_response
+
+        email = service.generate_email_campaign(
+            "Test Biz", "Sales", "Everyone", ["Point 1"]
+        )
+
+        assert email == expected_email
+
+    def test_analyze_competitor(self):
+        """Test competitor analysis."""
+        service = self.OpenAIService()
+
+        expected_analysis = {
+            "strengths": ["Strong"],
+            "weaknesses": ["Weak"]
+        }
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(expected_analysis)
+
+        self.mock_openai.ChatCompletion.create.return_value = mock_response
+
+        analysis = service.analyze_competitor("Competitor X", "Tech")
+
+        assert analysis == expected_analysis
+
+    def test_factory_method(self):
+        """Test IntegrationFactory creates OpenAIService."""
+        service = self.IntegrationFactory.get_openai_service()
+        assert isinstance(service, self.OpenAIService)
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_sendgrid_service.py
+++ b/tests/test_sendgrid_service.py
@@ -1,0 +1,151 @@
+"""
+Tests for SendGridService Integration
+Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights Reserved. PATENT PENDING.
+"""
+import pytest
+import sys
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Mock dependencies for initial import
+sys.modules["sendgrid"] = MagicMock()
+sys.modules["sendgrid.helpers.mail"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+sys.modules["fastapi"] = MagicMock()
+sys.modules["fastapi.status"] = MagicMock()
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from blank_business_builder import integrations
+
+class TestSendGridService:
+    """Test SendGridService functionality."""
+
+    def setup_method(self):
+        # Mock dependencies
+        self.mock_sendgrid = MagicMock()
+        sys.modules["sendgrid"] = self.mock_sendgrid
+        sys.modules["sendgrid.helpers.mail"] = MagicMock()
+        sys.modules["requests"] = MagicMock()
+
+        # Mock FastAPI
+        class MockHTTPException(Exception):
+            def __init__(self, status_code, detail):
+                self.status_code = status_code
+                self.detail = detail
+
+        mock_fastapi = MagicMock()
+        mock_fastapi.HTTPException = MockHTTPException
+        mock_fastapi.status = MagicMock()
+        mock_fastapi.status.HTTP_501_NOT_IMPLEMENTED = 501
+        mock_fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR = 500
+        sys.modules["fastapi"] = mock_fastapi
+        sys.modules["fastapi.status"] = mock_fastapi.status
+
+        # Reload module
+        importlib.reload(integrations)
+        self.SendGridService = integrations.SendGridService
+        self.IntegrationFactory = integrations.IntegrationFactory
+        self.MockHTTPException = MockHTTPException
+
+        # Reset mocks
+        self.mock_client_instance = self.mock_sendgrid.SendGridAPIClient.return_value
+        self.mock_client_instance.reset_mock()
+        self.mock_client_instance.send.side_effect = None
+
+    def test_initialization(self):
+        """Test initialization with and without API key."""
+        # With API Key
+        with patch.dict('os.environ', {'SENDGRID_API_KEY': 'SG.test_key'}):
+            service = self.SendGridService()
+            assert service.client is not None
+            self.mock_sendgrid.SendGridAPIClient.assert_called_with('SG.test_key')
+
+        # Without API Key
+        with patch.dict('os.environ', {}, clear=True):
+            service = self.SendGridService()
+            assert service.client is None
+
+    def test_send_email_success(self):
+        """Test sending a single email successfully."""
+        with patch.dict('os.environ', {'SENDGRID_API_KEY': 'SG.test_key'}):
+            service = self.SendGridService()
+
+            # Mock successful send
+            mock_response = MagicMock()
+            mock_response.status_code = 202
+            service.client.send.return_value = mock_response
+
+            result = service.send_email(
+                "test@example.com", "Subject", "Content"
+            )
+
+            assert result is True
+            service.client.send.assert_called_once()
+
+    def test_send_email_not_configured(self):
+        """Test sending email when not configured."""
+        with patch.dict('os.environ', {}, clear=True):
+            service = self.SendGridService()
+
+            with pytest.raises(self.MockHTTPException) as excinfo:
+                service.send_email("test@example.com", "Subject", "Content")
+
+            assert excinfo.value.status_code == 501
+            assert "not configured" in excinfo.value.detail
+
+    def test_send_email_failure(self):
+        """Test sending email failure."""
+        with patch.dict('os.environ', {'SENDGRID_API_KEY': 'SG.test_key'}):
+            service = self.SendGridService()
+
+            # Mock failure
+            service.client.send.side_effect = Exception("SendGrid Error")
+
+            with pytest.raises(self.MockHTTPException) as excinfo:
+                service.send_email("test@example.com", "Subject", "Content")
+
+            assert excinfo.value.status_code == 500
+            assert "SendGrid Error" in excinfo.value.detail
+
+    def test_send_bulk_email(self):
+        """Test sending bulk emails."""
+        with patch.dict('os.environ', {'SENDGRID_API_KEY': 'SG.test_key'}):
+            service = self.SendGridService()
+
+            # Mock send
+            mock_response = MagicMock()
+            mock_response.status_code = 202
+            service.client.send.return_value = mock_response
+
+            emails = ["u1@example.com", "u2@example.com"]
+            result = service.send_bulk_email(
+                emails, "Subject", "Content"
+            )
+
+            assert result["success"] == 2
+            assert result["failed"] == 0
+            assert service.client.send.call_count == 2
+
+    def test_send_transactional_email(self):
+        """Test sending transactional email."""
+        with patch.dict('os.environ', {'SENDGRID_API_KEY': 'SG.test_key'}):
+            service = self.SendGridService()
+
+            mock_response = MagicMock()
+            mock_response.status_code = 202
+            service.client.send.return_value = mock_response
+
+            result = service.send_transactional_email(
+                "u1@example.com", "template-id", {"name": "User"}
+            )
+
+            assert result is True
+            service.client.send.assert_called_once()
+
+    def test_factory_method(self):
+        """Test IntegrationFactory creates SendGridService."""
+        service = self.IntegrationFactory.get_sendgrid_service()
+        assert isinstance(service, self.SendGridService)


### PR DESCRIPTION
Added comprehensive unit tests for `OpenAIService`, `SendGridService`, and `BufferService` in `src/blank_business_builder/integrations.py`. The tests cover initialization, main functionality, and error handling. The tests use `unittest.mock` to mock external dependencies (`openai`, `sendgrid`, `requests`) and `importlib.reload` to ensure test isolation and correct handling of optional dependencies. Existing `tests/test_anthropic_service.py` was also updated to align with this pattern. This ensures that the integration services are thoroughly tested even in environments where the external libraries are not installed.

---
*PR created automatically by Jules for task [10555234028138085742](https://jules.google.com/task/10555234028138085742) started by @Workofarttattoo*