### PR TITLE
Implement JSON Schema validation in functions.do

### DIFF
--- a/frameworks/ai-platform/packages/functions.do/package.json
+++ b/frameworks/ai-platform/packages/functions.do/package.json
@@ -29,6 +29,8 @@
   "author": "dot-do",
   "license": "MIT",
   "dependencies": {
+    "ajv": "catalog:",
+    "ajv-formats": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/frameworks/ai-platform/packages/functions.do/src/validation.ts
+++ b/frameworks/ai-platform/packages/functions.do/src/validation.ts
@@ -3,7 +3,20 @@
  */
 
 import { z } from 'zod'
+import Ajv from 'ajv'
+import addFormats from 'ajv-formats'
 import type { Schema } from './types'
+
+// Initialize Ajv
+const ajv = new Ajv({
+  allErrors: true,
+  strict: false,
+  useDefaults: true,
+})
+addFormats(ajv)
+
+// Cache for compiled validators
+const validatorCache = new WeakMap<object, any>()
 
 /**
  * Check if schema is Zod schema
@@ -13,27 +26,48 @@ function isZodSchema(schema: Schema): schema is z.ZodType {
 }
 
 /**
+ * Get or compile validator for a JSON schema
+ */
+function getValidator(schema: object) {
+  let validate = validatorCache.get(schema)
+  if (!validate) {
+    validate = ajv.compile(schema)
+    validatorCache.set(schema, validate)
+  }
+  return validate
+}
+
+/**
+ * Internal validation logic
+ */
+function validateSchema<T>(schema: Schema<T>, data: unknown): T {
+  if (isZodSchema(schema)) {
+    return schema.parse(data)
+  }
+
+  // JSON Schema validation
+  const validate = getValidator(schema as object)
+  const valid = validate(data)
+
+  if (!valid) {
+    throw new Error(
+      `Validation failed: ${validate.errors?.map((e: any) => `${e.instancePath} ${e.message}`).join(', ')}`,
+    )
+  }
+
+  return data as T
+}
+
+/**
  * Validate input against schema
  */
 export function validateInput<T>(schema: Schema<T>, input: unknown): T {
-  if (isZodSchema(schema)) {
-    return schema.parse(input)
-  }
-
-  // JSON Schema validation (basic)
-  // TODO: Use a JSON Schema validator library
-  return input as T
+  return validateSchema(schema, input)
 }
 
 /**
  * Validate output against schema
  */
 export function validateOutput<T>(schema: Schema<T>, output: unknown): T {
-  if (isZodSchema(schema)) {
-    return schema.parse(output)
-  }
-
-  // JSON Schema validation (basic)
-  // TODO: Use a JSON Schema validator library
-  return output as T
+  return validateSchema(schema, output)
 }


### PR DESCRIPTION
Replaced basic type casting in validateInput and validateOutput with actual JSON Schema validation using the Ajv library. Optimized compilation with a WeakMap cache and added support for ajv-formats.

---
*PR created automatically by Jules for task [15248798356806985882](https://jules.google.com/task/15248798356806985882) started by @Workofarttattoo*