### PR TITLE
⚡ Bolt: [performance improvement] Optimize lead scoring and stage determination loops

### DIFF
--- a/src/blank_business_builder/smart_lead_nurturing.py
+++ b/src/blank_business_builder/smart_lead_nurturing.py
@@ -89,10 +89,22 @@ class SmartLeadScorer:
         if not interactions:
             return 0.0
 
-        email_opens = sum(1 for i in interactions if i.get('type') == 'email_open')
-        email_clicks = sum(1 for i in interactions if i.get('type') == 'email_click')
-        page_views = sum(1 for i in interactions if i.get('type') == 'page_view')
-        demo_requests = sum(1 for i in interactions if i.get('type') == 'demo_request')
+        # Bolt Optimization: Single O(N) iteration instead of multiple sum() generators
+        email_opens = 0
+        email_clicks = 0
+        page_views = 0
+        demo_requests = 0
+
+        for i in interactions:
+            interaction_type = i.get('type')
+            if interaction_type == 'email_open':
+                email_opens += 1
+            elif interaction_type == 'email_click':
+                email_clicks += 1
+            elif interaction_type == 'page_view':
+                page_views += 1
+            elif interaction_type == 'demo_request':
+                demo_requests += 1
 
         # Weighted scoring
         score = (
@@ -218,8 +230,17 @@ class LeadNurturingEngine:
 
     def _determine_stage(self, score: float, interactions: List[Dict]) -> str:
         """Determine lead stage based on score and behavior."""
-        demo_requested = any(i.get('type') == 'demo_request' for i in interactions)
-        trial_started = any(i.get('type') == 'trial_signup' for i in interactions)
+        # Bolt Optimization: Single O(N) loop that short-circuits early for highest priority
+        demo_requested = False
+        trial_started = False
+
+        for i in interactions:
+            interaction_type = i.get('type')
+            if interaction_type == 'trial_signup':
+                trial_started = True
+                break  # Highest priority condition met, short-circuit
+            elif interaction_type == 'demo_request':
+                demo_requested = True
 
         if trial_started:
             return "hot"


### PR DESCRIPTION
💡 What: 
- Replaced four separate `sum()` generators with a single `for` loop in `SmartLeadScorer._calculate_engagement_score`.
- Replaced two `any()` calls with a single `for` loop that short-circuits early when the highest priority event (`trial_signup`) is found in `LeadNurturingEngine._determine_stage`.

🎯 Why: 
Multiple generator expressions over the `interactions` list were causing redundant O(N) traversals for every lead scored or staged.

📊 Impact: 
Reduces algorithmic complexity of iterating interactions in `_calculate_engagement_score` from O(4N) to O(N).
Reduces worst-case complexity in `_determine_stage` from O(2N) to O(N), with best-case O(1) if `trial_signup` is found early.

🔬 Measurement: 
Ran the `tests/test_smart_lead_nurturing.py` test suite via `pytest` to confirm 100% pass rate with zero regressions. The code maintains the original correct logic while utilizing fewer loop iterations.

---
*PR created automatically by Jules for task [11357505544593685132](https://jules.google.com/task/11357505544593685132) started by @Workofarttattoo*