### PR TITLE
⚡ Bolt: [performance improvement] Optimize feature category metrics calculation

### DIFF
--- a/src/blank_business_builder/quantum_features_master.py
+++ b/src/blank_business_builder/quantum_features_master.py
@@ -414,12 +414,26 @@ class QuantumFeatureRegistry:
         for category in FeatureCategory:
             features = self.get_features_by_category(category)
             if features:
+                # ⚡ Bolt Optimization: Calculate all totals in a single O(N) pass
+                # instead of 4 separate O(N) sum generator expressions.
+                total_impact = 0.0
+                total_user_value = 0.0
+                total_revenue_potential = 0.0
+                total_complexity = 0.0
+
+                for f in features:
+                    total_impact += f.impact
+                    total_user_value += f.user_value
+                    total_revenue_potential += f.revenue_potential
+                    total_complexity += f.complexity
+
+                feature_count = len(features)
                 category_metrics[category.value] = {
-                    "avg_impact": sum(f.impact for f in features) / len(features),
-                    "avg_user_value": sum(f.user_value for f in features) / len(features),
-                    "avg_revenue_potential": sum(f.revenue_potential for f in features) / len(features),
-                    "avg_complexity": sum(f.complexity for f in features) / len(features),
-                    "feature_count": len(features)
+                    "avg_impact": total_impact / feature_count,
+                    "avg_user_value": total_user_value / feature_count,
+                    "avg_revenue_potential": total_revenue_potential / feature_count,
+                    "avg_complexity": total_complexity / feature_count,
+                    "feature_count": feature_count
                 }
 
         return category_metrics


### PR DESCRIPTION
💡 **What:** 
Replaced 4 separate `sum(f.property for f in features)` generator expressions with a single O(N) `for` loop iteration that simultaneously tallies `total_impact`, `total_user_value`, `total_revenue_potential`, and `total_complexity`. 

🎯 **Why:** 
The original implementation traversed the same list of features four separate times for each category, allocating four generator expressions. This resulted in redundant list traversals.

📊 **Impact:** 
Reduces list traversals for category metrics from O(4N) per category down to O(N). Lowers CPU utilization and memory overhead by avoiding the creation of four distinct generator objects.

🔬 **Measurement:** 
Run `python -c 'from src.blank_business_builder.quantum_features_master import feature_registry; print(feature_registry.get_category_metrics())'` and verify output is identical to the previous implementation. Output was identical in tests.

---
*PR created automatically by Jules for task [6988951804831703906](https://jules.google.com/task/6988951804831703906) started by @Workofarttattoo*