### PR TITLE
⚡ Bolt: [performance improvement] optimize _calculate_engagement_score

### DIFF
--- a/src/blank_business_builder/smart_lead_nurturing.py
+++ b/src/blank_business_builder/smart_lead_nurturing.py
@@ -89,10 +89,23 @@ class SmartLeadScorer:
         if not interactions:
             return 0.0
 
-        email_opens = sum(1 for i in interactions if i.get('type') == 'email_open')
-        email_clicks = sum(1 for i in interactions if i.get('type') == 'email_click')
-        page_views = sum(1 for i in interactions if i.get('type') == 'page_view')
-        demo_requests = sum(1 for i in interactions if i.get('type') == 'demo_request')
+        # ⚡ Bolt Optimization: Replaced 4 O(N) generator expressions with a single O(N) loop.
+        # This reduces list traversals from 4N to N and reduces .get('type') dictionary lookups by 75%.
+        email_opens = 0
+        email_clicks = 0
+        page_views = 0
+        demo_requests = 0
+
+        for i in interactions:
+            itype = i.get('type')
+            if itype == 'email_open':
+                email_opens += 1
+            elif itype == 'email_click':
+                email_clicks += 1
+            elif itype == 'page_view':
+                page_views += 1
+            elif itype == 'demo_request':
+                demo_requests += 1
 
         # Weighted scoring
         score = (


### PR DESCRIPTION
💡 What: Replaced 4 O(N) generator expressions with a single O(N) loop to compute engagement counts (`email_opens`, `email_clicks`, `page_views`, `demo_requests`).
🎯 Why: Iterating over the `interactions` list 4 times is redundant and wasteful, particularly as the list of a lead's interactions grows over time.
📊 Impact: Reduces list traversals from 4N to N and reduces `.get('type')` dictionary lookups by 75%. This provides a measurable reduction in CPU cycles for large interactions lists.
🔬 Measurement: Verified functionality using `pytest tests/test_smart_lead_nurturing.py` to ensure behavior is identical.

---
*PR created automatically by Jules for task [13467953633835741476](https://jules.google.com/task/13467953633835741476) started by @Workofarttattoo*