### PR TITLE
⚡ Bolt: [performance improvement] Collapse multiple list traversals into single O(N) loops

### DIFF
--- a/src/blank_business_builder/quantum_features_master.py
+++ b/src/blank_business_builder/quantum_features_master.py
@@ -414,12 +414,28 @@ class QuantumFeatureRegistry:
         for category in FeatureCategory:
             features = self.get_features_by_category(category)
             if features:
+                # ⚡ Bolt Optimization: Replace 4 sequential list comprehensions traversing
+                # `features` to compute `sum(f.attr...)` with a single O(N) `for` loop iteration
+                # across all impact, user_value, revenue, and complexity fields at once.
+                total_impact = 0.0
+                total_user_value = 0.0
+                total_revenue_potential = 0.0
+                total_complexity = 0.0
+
+                for f in features:
+                    total_impact += f.impact
+                    total_user_value += f.user_value
+                    total_revenue_potential += f.revenue_potential
+                    total_complexity += f.complexity
+
+                feature_count = len(features)
+
                 category_metrics[category.value] = {
-                    "avg_impact": sum(f.impact for f in features) / len(features),
-                    "avg_user_value": sum(f.user_value for f in features) / len(features),
-                    "avg_revenue_potential": sum(f.revenue_potential for f in features) / len(features),
-                    "avg_complexity": sum(f.complexity for f in features) / len(features),
-                    "feature_count": len(features)
+                    "avg_impact": total_impact / feature_count,
+                    "avg_user_value": total_user_value / feature_count,
+                    "avg_revenue_potential": total_revenue_potential / feature_count,
+                    "avg_complexity": total_complexity / feature_count,
+                    "feature_count": feature_count
                 }
 
         return category_metrics

--- a/src/blank_business_builder/qulab_rental_business.py
+++ b/src/blank_business_builder/qulab_rental_business.py
@@ -407,10 +407,24 @@ class QuLabRentalBusiness:
             raise ValueError(f"Customer {customer_id} not found")
 
         plan = PRICING_PLANS[customer.tier]
-        customer_jobs = [j for j in self.jobs if j.customer_id == customer_id]
 
-        completed_jobs = [j for j in customer_jobs if j.status == "completed"]
-        failed_jobs = [j for j in customer_jobs if j.status == "failed"]
+        # ⚡ Bolt Optimization: Replaced multiple list comprehensions
+        # filtering `self.jobs` with a single O(N) pass over the list.
+        jobs_completed = 0
+        jobs_failed = 0
+        total_qubits_completed = 0
+        total_simulation_minutes = 0.0
+        priority_counts = Counter()
+
+        for j in self.jobs:
+            if j.customer_id == customer_id:
+                priority_counts[j.priority.value] += 1
+                if j.status == "completed":
+                    jobs_completed += 1
+                    total_qubits_completed += j.num_qubits
+                    total_simulation_minutes += j.simulation_minutes
+                elif j.status == "failed":
+                    jobs_failed += 1
 
         return {
             "customer_id": customer_id,
@@ -423,16 +437,14 @@ class QuLabRentalBusiness:
                 "included_hours": plan.included_hours,
                 "overage_hours": max(0, customer.qubit_hours_used - plan.included_hours),
                 "jobs_submitted": customer.jobs_submitted,
-                "jobs_completed": len(completed_jobs),
-                "jobs_failed": len(failed_jobs),
+                "jobs_completed": jobs_completed,
+                "jobs_failed": jobs_failed,
                 "total_spent": float(customer.total_spent)
             },
             "usage_breakdown": {
-                "avg_qubits_per_job": sum(j.num_qubits for j in completed_jobs) / max(1, len(completed_jobs)),
-                "total_simulation_minutes": sum(j.simulation_minutes for j in completed_jobs),
-                "most_used_priority": Counter(
-                    j.priority.value for j in customer_jobs
-                ).most_common(1)[0][0] if customer_jobs else "none"
+                "avg_qubits_per_job": total_qubits_completed / max(1, jobs_completed),
+                "total_simulation_minutes": total_simulation_minutes,
+                "most_used_priority": priority_counts.most_common(1)[0][0] if priority_counts else "none"
             },
             "recommendations": self._generate_recommendations(customer)
         }
@@ -496,15 +508,28 @@ class QuLabRentalBusiness:
 
     def get_business_metrics(self) -> Dict[str, Any]:
         """Get overall business metrics."""
+        # ⚡ Bolt Optimization: Tally active customers and tier distribution in a single pass
+        # avoiding an O(T*N) dict comprehension.
+        active_customers = 0
+        tier_distribution = {tier.value: 0 for tier in SubscriptionTier}
+
+        for c in self.customers.values():
+            if c.subscription_status == "active":
+                active_customers += 1
+            tier_distribution[c.tier.value] += 1
+
+        # ⚡ Bolt Optimization: Count completed jobs in a single pass instead of a list comprehension
+        completed_jobs = 0
+        for j in self.jobs:
+            if j.status == "completed":
+                completed_jobs += 1
+
         return {
             "total_customers": len(self.customers),
-            "active_customers": len([c for c in self.customers.values() if c.subscription_status == "active"]),
-            "tier_distribution": {
-                tier.value: len([c for c in self.customers.values() if c.tier == tier])
-                for tier in SubscriptionTier
-            },
+            "active_customers": active_customers,
+            "tier_distribution": tier_distribution,
             "total_jobs": len(self.jobs),
-            "completed_jobs": len([j for j in self.jobs if j.status == "completed"]),
+            "completed_jobs": completed_jobs,
             "total_qubit_hours": self.total_qubit_hours,
             "total_revenue": float(self.revenue),
             "avg_revenue_per_customer": float(self.revenue / max(1, len(self.customers))),


### PR DESCRIPTION
**💡 What**:
Optimized `get_usage_analytics` and `get_business_metrics` in `src/blank_business_builder/qulab_rental_business.py` and `get_category_metrics` in `src/blank_business_builder/quantum_features_master.py` to condense multiple consecutive list comprehensions or `sum()` generators into single `for` loop traversals.

**🎯 Why**:
Prior to this change, generating metrics required the codebase to traverse the same arrays (features, customers, jobs) multiple times. For example, `get_category_metrics` looped over all features four times to calculate average metrics, and `get_business_metrics` executed an `O(T*N)` pass across customers and tiers. Collapsing these into single iterations avoids redundant data traversal overhead, drastically improving execution efficiency as the dataset grows.

**📊 Impact**:
Reduces time complexity overhead per function call. For example, generating tier distributions shifts from `O(T * N)` (Tiers * Customers) down to `O(N)` (Customers), directly improving backend response times for analytics queries.

**🔬 Measurement**:
Tests have been executed via `pytest tests/test_quantum_optimizer.py` and embedded demo runs (`python -c "from src.blank_business_builder.qulab_rental_business import demo_qulab_rental; import asyncio; asyncio.run(demo_qulab_rental())"`). Outputs were manually verified against the baseline format.

---
*PR created automatically by Jules for task [33819267800955665](https://jules.google.com/task/33819267800955665) started by @Workofarttattoo*