### PR TITLE
⚡ Bolt: O(N) optimization for Magic R&D Lab metrics

### DIFF
--- a/src/blank_business_builder/magic_rd_lab.py
+++ b/src/blank_business_builder/magic_rd_lab.py
@@ -246,12 +246,22 @@ class MagicRDLab:
         if not customer:
             raise ValueError(f"Customer {customer_id} not found")
 
-        customer_sessions = [s for s in self.sessions if s.customer_email == customer.email]
-        active_sessions = [s for s in customer_sessions if s.status == "active"]
-        completed_sessions = [s for s in customer_sessions if s.status == "completed"]
+        # ⚡ Bolt Optimization: Replace multiple list comprehensions with single O(N) concurrent pass
+        total_sessions = 0
+        active_sessions = []
+        completed_sessions = 0
+        total_hours = 0
+        total_computations = 0
 
-        total_hours = sum(PACKAGE_PRICING[s.package]["hours"] for s in customer_sessions)
-        total_computations = sum(len(s.results) for s in customer_sessions)
+        for s in self.sessions:
+            if s.customer_email == customer.email:
+                total_sessions += 1
+                total_hours += PACKAGE_PRICING[s.package]["hours"]
+                total_computations += len(s.results)
+                if s.status == "active":
+                    active_sessions.append(s)
+                elif s.status == "completed":
+                    completed_sessions += 1
 
         return {
             "customer_id": customer.customer_id,
@@ -262,14 +272,14 @@ class MagicRDLab:
             "member_since": customer.created_at.isoformat(),
             "total_spent": float(customer.total_spent),
             "sessions": {
-                "total": len(customer_sessions),
+                "total": total_sessions,
                 "active": len(active_sessions),
-                "completed": len(completed_sessions)
+                "completed": completed_sessions
             },
             "usage": {
                 "total_hours_purchased": total_hours,
                 "total_computations": total_computations,
-                "avg_computations_per_session": total_computations / max(1, len(customer_sessions))
+                "avg_computations_per_session": total_computations / max(1, total_sessions)
             },
             "active_sessions": [
                 {
@@ -342,24 +352,29 @@ class MagicRDLab:
 
     def get_business_metrics(self) -> Dict[str, Any]:
         """Get business performance metrics."""
-        active_sessions = [s for s in self.sessions if s.status == "active"]
-        completed_sessions = [s for s in self.sessions if s.status == "completed"]
+        # ⚡ Bolt Optimization: Replace multiple list comprehensions with single O(N) concurrent pass
+        active_sessions = 0
+        completed_sessions = 0
+        package_dist = {package.value: 0 for package in RentalPackage}
+        total_computations = 0
 
-        # Package distribution
-        package_dist = {}
-        for package in RentalPackage:
-            count = len([s for s in self.sessions if s.package == package])
-            package_dist[package.value] = count
+        for s in self.sessions:
+            if s.status == "active":
+                active_sessions += 1
+            elif s.status == "completed":
+                completed_sessions += 1
+            package_dist[s.package.value] += 1
+            total_computations += len(s.results)
 
         return {
             "total_revenue": float(self.revenue),
             "total_customers": len(self.customers),
             "total_sessions": len(self.sessions),
-            "active_sessions": len(active_sessions),
-            "completed_sessions": len(completed_sessions),
+            "active_sessions": active_sessions,
+            "completed_sessions": completed_sessions,
             "package_distribution": package_dist,
             "avg_revenue_per_customer": float(self.revenue / max(1, len(self.customers))),
-            "total_computations": sum(len(s.results) for s in self.sessions)
+            "total_computations": total_computations
         }
 
 


### PR DESCRIPTION
**💡 What:**
Refactored `get_customer_dashboard` and `get_business_metrics` in `src/blank_business_builder/magic_rd_lab.py` to use a single O(N) loop instead of multiple list comprehensions.

**🎯 Why:**
The original implementation ran 4-5 list comprehensions over the `self.sessions` list (or `customer_sessions` list) in each method call. For `get_business_metrics`, it also had a nested loop over the Enum values. This resulted in O(k * N) complexity (where k is the number of loops/comprehensions) per call, which becomes a bottleneck as the number of sessions grows. Consolidating this logic into a single iteration avoids redundant list traversals.

**📊 Impact:**
Reduces the algorithmic constant from ~O(4N) to O(N) for each method call, improving response times and reducing memory allocations (from building intermediate list objects during list comprehensions).

**🔬 Measurement:**
Tested locally via direct file execution (`python -c "from src.blank_business_builder.magic_rd_lab import demo_magic_rd_lab; import asyncio; asyncio.run(demo_magic_rd_lab())"`) and verified test execution (`pytest tests/test_magic_rd_lab.py`). Tests pass and the business logic behaves identically.

---
*PR created automatically by Jules for task [9322611204633170846](https://jules.google.com/task/9322611204633170846) started by @Workofarttattoo*