### PR TITLE
Fix: Onboarding hangs at business selection stage

### DIFF
--- a/src/blank_business_builder/business_builder_gui.html
+++ b/src/blank_business_builder/business_builder_gui.html
@@ -751,12 +751,19 @@
                     if (i >= logs.length) {
                         clearInterval(interval);
                         progress.style.width = '100%';
-                        setTimeout(() => {
-                            // Pass recommendations directly if available, else fetch
-                            if (data.recommendations) {
-                                renderRecommendations(data.recommendations);
-                            } else {
-                                loadRecommendations();
+                        setTimeout(async () => {
+                            try {
+                                // Pass recommendations directly if available, else fetch
+                                if (data.recommendations && data.recommendations.length > 0) {
+                                    renderRecommendations(data.recommendations);
+                                } else {
+                                    await loadRecommendations();
+                                }
+                            } catch (err) {
+                                console.error('Failed to load recommendations:', err);
+                                document.getElementById('recommendations-list').innerHTML =
+                                    '<p style="text-align:center;color:var(--secondary);">⚠️ Could not load recommendations. Please restart the analysis.</p>';
+                                document.getElementById('btn-research').disabled = false;
                             }
                             nextStep(5);
                         }, 1000);
@@ -776,15 +783,32 @@
 
         // Step 5: Recommendations
         async function loadRecommendations() {
-            const res = await fetch(`${API}/recommendations`);
-            const ideas = await res.json();
-            renderRecommendations(ideas);
+            try {
+                const res = await fetch(`${API}/recommendations`);
+                if (!res.ok) throw new Error(`Server returned ${res.status}`);
+                const ideas = await res.json();
+                renderRecommendations(ideas);
+            } catch (err) {
+                console.error('loadRecommendations failed:', err);
+                throw err; // re-throw so caller can handle
+            }
         }
 
         function renderRecommendations(ideas) {
             const container = document.getElementById('recommendations-list');
-            container.innerHTML = ideas.map(idea => `
-                <div class="business-option" onclick="selectBusiness(this, '${idea.name}')">
+            if (!ideas || ideas.length === 0) {
+                container.innerHTML = `
+                    <div style="text-align:center; padding: 2rem;">
+                        <p style="font-size: 1.2rem; margin-bottom: 1rem;">🔍 No matching businesses found for your criteria.</p>
+                        <p style="color: var(--text-dim);">Try adjusting your budget, hours, or industry preference.</p>
+                    </div>`;
+                return;
+            }
+            container.innerHTML = ideas.map(idea => {
+                // Escape name for safe use in onclick attribute
+                const safeName = idea.name.replace(/'/g, "\\'").replace(/"/g, '&quot;');
+                return `
+                <div class="business-option" onclick="selectBusiness(this, '${safeName}')">
                     <h3 style="color: var(--primary)">${idea.name}</h3>
                     <p style="font-size: 0.9rem; color: var(--text-dim);">${idea.industry}</p>
                     <p style="margin: 0.5rem 0;">${idea.description}</p>
@@ -793,8 +817,8 @@
                         <span>🚀 Cost: $${idea.startup_cost}</span>
                         <span>⏱ ${idea.time_commitment_hours_per_week}h/week</span>
                     </div>
-                </div>
-            `).join('');
+                </div>`;
+            }).join('');
         }
 
         function selectBusiness(el, name) {

--- a/src/blank_business_builder/gui_server.py
+++ b/src/blank_business_builder/gui_server.py
@@ -208,7 +208,9 @@ async def run_research():
     update_app_state("analysis_results", result["recommendations"])
     update_app_state("research_logs", result["logs"])
 
-    return {"logs": result["logs"]}
+    # Return both logs AND recommendations so the frontend can render immediately
+    # without needing a second fetch (which caused a race condition / silent hang)
+    return {"logs": result["logs"], "recommendations": result["recommendations"]}
 
 @app.get("/api/recommendations")
 async def get_recommendations():


### PR DESCRIPTION
## Problem

The onboarding wizard freezes at Step 5 (Select Your Business) after the OSINT research phase completes. Users see "Loading recommendations..." indefinitely with no way to recover.

## Root Cause — Three bugs working together

### Bug 1: `/api/research` omits recommendations from response
The endpoint scores all 49 business models and stores results in state, but only returns `{logs: [...]}` — forcing the frontend into a fallback fetch to `/api/recommendations`.

### Bug 2: Missing `await` on `loadRecommendations()`
The fallback fetch is `async` but called without `await` inside a `setTimeout` callback. `nextStep(5)` fires immediately, transitioning the UI before the fetch completes. If the fetch fails, the promise rejection is silently swallowed — "Loading recommendations..." forever.

### Bug 3: No handling for empty results or errors
If zero businesses pass scoring, `renderRecommendations([])` clears the container to blank HTML. Confirm button stays disabled permanently.

## Fixes

| File | Change |
|------|--------|
| `gui_server.py` | Return recommendations alongside logs in `/api/research` response |
| `business_builder_gui.html` | `await` the `loadRecommendations()` call + `try/catch` with error UI |
| `business_builder_gui.html` | Handle empty recommendations with user-friendly message |
| `business_builder_gui.html` | Escape business names in `onclick` attributes (XSS prevention) |
| `business_builder_gui.html` | Re-enable research button on error for retry |