### PR TITLE
🧪 Refactor demo and test KeyboardInterrupt in main module

### DIFF
--- a/scripts/demos/demo_red_team_subscription.py
+++ b/scripts/demos/demo_red_team_subscription.py
@@ -88,8 +88,11 @@ async def demo():
     except Exception as e:
         print(f"\nError during demo: {e}")
 
-if __name__ == "__main__":
+def main():
     try:
         asyncio.run(demo())
     except KeyboardInterrupt:
         print("\nDemo interrupted.")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demo_red_team_subscription.py
+++ b/tests/test_demo_red_team_subscription.py
@@ -1,0 +1,31 @@
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Mock sys.exit before importing the module because it calls sys.exit(1) on import failure
+with patch("sys.exit"):
+    import os
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'scripts', 'demos')))
+    from demo_red_team_subscription import main
+
+def test_main_keyboard_interrupt(capsys):
+    """Test that main() handles KeyboardInterrupt properly."""
+
+    # Run the main function, mock asyncio.run
+    # the unraisable warning is from unittest.mock trying to be smart about async functions
+    # Let's mock demo using a standard patch but ensure we close the coroutine if needed
+
+    import asyncio
+
+    async def dummy_coroutine():
+        pass
+
+    def mock_run(coro):
+        coro.close() # Close to prevent warnings
+        raise KeyboardInterrupt()
+
+    with patch('demo_red_team_subscription.asyncio.run', side_effect=mock_run):
+        main()
+
+    captured = capsys.readouterr()
+    assert "\nDemo interrupted.\n" in captured.out


### PR DESCRIPTION
🎯 **What:** The `demo_red_team_subscription.py` `__main__` block lacked test coverage for `KeyboardInterrupt` interruption handling. The main execution block was refactored into a testable `main()` function.

📊 **Coverage:** Added a new test `test_main_keyboard_interrupt` that mocks `sys.exit` and `asyncio.run` to properly cover the interrupt branch and assert the stdout message.

✨ **Result:** The script entry point is now safely covered by unit tests, increasing system reliability and test coverage without unawaited coroutine warnings.

---
*PR created automatically by Jules for task [7048113417352394811](https://jules.google.com/task/7048113417352394811) started by @Workofarttattoo*