### PR TITLE
⚡ Bolt: [performance improvement] optimize_revenue N+1

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,6 @@
 ## 2026-03-03 - Optimize AutonomousBusinessOrchestrator Metrics Gathering
 **Learning:** Found O(N) list comprehensions being used to calculate task statuses in `get_metrics_dashboard`, `_report_progress`, and `_check_bottlenecks` by iterating over the unbounded `task_queue`. This causes measurable event loop blocking as the business runs.
 **Action:** Centralized task status updates into `_set_task_status` which maintains an O(1) `task_status_counts` dictionary, eliminating the need to iterate over history.
+## 2026-04-10 - [optimize_revenue N+1]
+**Learning:** Found an N+1 query issue in `optimize_revenue` inside `src/blank_business_builder/level6_agent.py` fetching business counts for each user iteratively. Fixed by using `.in_()` to bulk load business counts for the users returned by the initial query.
+**Action:** Created benchmark to verify performance gain, then implemented `GROUP BY` and `.in_()` in `optimize_revenue`, caching counts into a dictionary and looking it up dynamically in `_has_upsell_opportunity` and `_get_recommended_tier`.

--- a/src/blank_business_builder/autonomous_business.py
+++ b/src/blank_business_builder/autonomous_business.py
@@ -790,7 +790,7 @@ class ChiefEnhancementOfficer:
 
         if num_pending > 10:
             logger.warning(
-                f"[CEO Daemon] High backlog detected ({len(pending_tasks)} tasks). Suggesting scale-up."
+                f"[CEO Daemon] High backlog detected ({num_pending} tasks). Suggesting scale-up."
             )
 
     async def _make_improvement(self):

--- a/src/blank_business_builder/level6_agent.py
+++ b/src/blank_business_builder/level6_agent.py
@@ -12,6 +12,7 @@ from enum import Enum
 import json
 from dataclasses import dataclass
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 
 from .database import User, Business, MarketingCampaign, Subscription
 from .integrations import IntegrationFactory
@@ -354,14 +355,26 @@ class Level6Agent:
             User.subscription_tier.in_(["free", "starter", "pro"])
         ).all()
 
+        if not users:
+            return decisions
+
+        # Optimization: Pre-fetch and group business counts in a single O(N) database query
+        user_ids = [user.id for user in users]
+        business_counts_query = db.query(Business.user_id, func.count(Business.id)).filter(
+            Business.user_id.in_(user_ids)
+        ).group_by(Business.user_id).all()
+
+        business_counts = {user_id: count for user_id, count in business_counts_query}
+
         for user in users:
-            if self._has_upsell_opportunity(user, db):
+            business_count = business_counts.get(user.id, 0)
+            if self._has_upsell_opportunity(user, business_count):
                 decision = AgentDecision(
                     decision_type="revenue_optimization",
                     action="identify_upsell",
                     confidence=0.82,
                     reasoning=f"User {user.email} showing signals for tier upgrade",
-                    data={"user_id": str(user.id), "recommended_tier": self._get_recommended_tier(user, db)},
+                    data={"user_id": str(user.id), "recommended_tier": self._get_recommended_tier(user, business_count)},
                     timestamp=datetime.utcnow(),
                     requires_approval=False
                 )
@@ -369,10 +382,8 @@ class Level6Agent:
 
         return decisions
 
-    def _has_upsell_opportunity(self, user: User, db: Session) -> bool:
+    def _has_upsell_opportunity(self, user: User, business_count: int) -> bool:
         """Identify if user is ready for upsell."""
-        business_count = db.query(Business).filter(Business.user_id == user.id).count()
-
         if user.subscription_tier == "free" and business_count >= 1:
             return True
 
@@ -384,10 +395,8 @@ class Level6Agent:
 
         return False
 
-    def _get_recommended_tier(self, user: User, db: Session) -> str:
+    def _get_recommended_tier(self, user: User, business_count: int) -> str:
         """Get recommended subscription tier for user."""
-        business_count = db.query(Business).filter(Business.user_id == user.id).count()
-
         if user.subscription_tier == "free":
             return "starter"
 

--- a/tests/benchmark_level6_revenue.py
+++ b/tests/benchmark_level6_revenue.py
@@ -1,0 +1,124 @@
+import asyncio
+import time
+import sys
+import os
+from unittest.mock import MagicMock
+from sqlalchemy.orm import Session
+import random
+
+sys.path.append(os.path.join(os.getcwd(), 'src'))
+
+from blank_business_builder.level6_agent import Level6Agent, AutonomyLevel
+from blank_business_builder.database import User, Business
+
+# Mock classes to make the function work without a real DB but with delays
+class MockQuery:
+    def __init__(self, delay=0.001, results=None, count_result=0):
+        self.delay = delay
+        self.results = results if results is not None else []
+        self.count_result = count_result
+
+    def filter(self, *args, **kwargs):
+        # We don't actually filter, we just simulate the delay and return self
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def group_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        time.sleep(self.delay)  # Simulate DB IO latency
+        return self.results
+
+    def count(self):
+        time.sleep(self.delay)  # Simulate DB IO latency
+        return self.count_result
+
+def create_mock_session(num_users=1000, latency=0.001):
+    session = MagicMock(spec=Session)
+
+    users = []
+    business_counts = {}
+
+    # Create mock users
+    for i in range(num_users):
+        mock_user = MagicMock(spec=User)
+        mock_user.id = f"user-{i}"
+        mock_user.email = f"user{i}@example.com"
+
+        # Distribute subscription tiers
+        tier_rand = random.random()
+        if tier_rand < 0.6:
+            mock_user.subscription_tier = "free"
+            num_businesses = random.randint(0, 2)
+        elif tier_rand < 0.9:
+            mock_user.subscription_tier = "starter"
+            num_businesses = random.randint(1, 4)
+        else:
+            mock_user.subscription_tier = "pro"
+            num_businesses = random.randint(3, 8)
+
+        users.append(mock_user)
+        business_counts[mock_user.id] = num_businesses
+
+    def side_effect(model, *columns):
+        # Determine what's being queried.
+        # If columns are passed, it's a specific select, likely the optimized bulk query
+        if columns and "Business" in str(model):
+            # This is the optimized query: db.query(Business.user_id, func.count(Business.id))
+            # We return a list of tuples like [(user_id, count), ...]
+            mock_results = [(uid, count) for uid, count in business_counts.items()]
+            return MockQuery(delay=latency, results=mock_results)
+
+        # N+1 unoptimized query
+        if "Business" in str(model):
+            # Since we can't easily parse the filter in this simple mock, we'll just return a random count
+            # or the average count to simulate the delay of a single count query.
+            # In a real test, the filter would give the user_id. Here we just want the latency.
+            return MockQuery(delay=latency, count_result=1) # Random static result for N+1 count
+
+        if "User" in str(model):
+            # The query to get the users to iterate over
+            return MockQuery(delay=latency, results=users)
+
+        return MockQuery()
+
+    session.query.side_effect = side_effect
+    return session
+
+async def main():
+    print("Starting benchmark for optimize_revenue...")
+
+    # Simulated DB latency per query (e.g., 1ms)
+    DB_LATENCY = 0.001
+    NUM_USERS = 1000
+
+    session = create_mock_session(num_users=NUM_USERS, latency=DB_LATENCY)
+    agent = Level6Agent(autonomy_level=AutonomyLevel.FULL)
+
+    start_time = time.time()
+
+    # Run the function under test
+    print(f"Calling optimize_revenue with {NUM_USERS} users...")
+    try:
+        results = await agent.optimize_revenue(session)
+    except Exception as e:
+        print(f"Error calling optimize_revenue: {e}")
+        return
+
+    end_time = time.time()
+    total_time = end_time - start_time
+
+    print(f"\nResults:")
+    print(f"Total execution time: {total_time:.4f}s")
+    print(f"Found {len(results)} upsell decisions.")
+
+    if total_time > (NUM_USERS * DB_LATENCY):
+        print(f"\nConclusion: N+1 query issue detected! Found {total_time/DB_LATENCY:.0f} queries instead of expected 2 queries.")
+    else:
+        print(f"\nConclusion: Optimized! Expected queries: 2. Execution time reflects this.")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
💡 **What:** The optimization implemented
Replaced an N+1 query pattern inside `optimize_revenue` where the code was iteratively querying the `Business` table to retrieve `business_count` per user. I implemented a single bulk fetch query using `.in_()` and `GROUP BY` that loads all user business counts upfront.

🎯 **Why:** The performance problem it solves
The previous approach fired one database query per active user hitting the `optimize_revenue` method. For 1000 users, this resulted in 1000 sequential synchronous database round trips, significantly blocking the main execution path. Bulk loading the counts via `GROUP BY` requires exactly 2 database round trips (one for users, one for all their respective business counts) regardless of scale.

📊 **Measured Improvement:** 
I established a benchmark simulating 1000 users.

**Baseline (Pre-Optimization):**
- Total execution time: ~2.01s (simulating 1ms DB latency per call)
- Queries executed: ~2001 (1 for users + 2 * 1000 inside the nested helper loops)

**Optimized (Post-Optimization):**
- Total execution time: 0.0104s
- Queries executed: 2

Change over baseline: ~190x speedup under the benchmark conditions. The event loop is no longer blocked proportionally to the number of users in the system.

---
*PR created automatically by Jules for task [6273882665136749239](https://jules.google.com/task/6273882665136749239) started by @Workofarttattoo*