### PR TITLE
⚡ Bolt: [performance improvement] fix N+1 query in manage_churn_prevention

### DIFF
--- a/patch_level6_agent.py
+++ b/patch_level6_agent.py
@@ -1,0 +1,144 @@
+import re
+
+with open("src/blank_business_builder/level6_agent.py", "r") as f:
+    content = f.read()
+
+# We need to add func from sqlalchemy
+if "from sqlalchemy import func" not in content:
+    content = content.replace("from sqlalchemy.orm import Session", "from sqlalchemy.orm import Session\nfrom sqlalchemy import func")
+
+# Replace manage_churn_prevention
+old_manage_churn_prevention = """
+    async def manage_churn_prevention(self, db: Session) -> List[AgentDecision]:
+        \"\"\"
+        Predictive churn prevention.
+        - Identify at-risk customers
+        - Automated retention campaigns
+        - Personalized intervention
+        \"\"\"
+        decisions = []
+
+        # Get paid subscribers
+        subscriptions = db.query(Subscription).filter(
+            Subscription.status == "active"
+        ).all()
+
+        for subscription in subscriptions:
+            churn_risk = self._calculate_churn_risk(subscription, db)
+
+            if churn_risk > 0.7:  # High risk
+                user = db.query(User).filter(User.id == subscription.user_id).first()
+                decision = await self._create_retention_campaign(user, churn_risk, db)
+                decisions.append(decision)
+
+        return decisions
+"""
+
+new_manage_churn_prevention = """
+    async def manage_churn_prevention(self, db: Session) -> List[AgentDecision]:
+        \"\"\"
+        Predictive churn prevention.
+        - Identify at-risk customers
+        - Automated retention campaigns
+        - Personalized intervention
+        \"\"\"
+        decisions = []
+
+        # Get paid subscribers
+        subscriptions = db.query(Subscription).filter(
+            Subscription.status == "active"
+        ).all()
+
+        if not subscriptions:
+            return decisions
+
+        # Bulk fetch users
+        user_ids = [sub.user_id for sub in subscriptions]
+        users = db.query(User).filter(User.id.in_(user_ids)).all()
+        user_dict = {user.id: user for user in users}
+
+        # Bulk fetch business counts
+        business_counts = dict(
+            db.query(Business.user_id, func.count(Business.id))
+            .filter(Business.user_id.in_(user_ids))
+            .group_by(Business.user_id)
+            .all()
+        )
+
+        for subscription in subscriptions:
+            user = user_dict.get(subscription.user_id)
+            if not user:
+                continue
+
+            business_count = business_counts.get(subscription.user_id, 0)
+            churn_risk = self._calculate_churn_risk(subscription, user, business_count)
+
+            if churn_risk > 0.7:  # High risk
+                decision = await self._create_retention_campaign(user, churn_risk, db)
+                decisions.append(decision)
+
+        return decisions
+"""
+
+content = content.replace(old_manage_churn_prevention.strip("\n"), new_manage_churn_prevention.strip("\n"))
+
+# Replace _calculate_churn_risk
+old_calculate_churn_risk = """
+    def _calculate_churn_risk(self, subscription: Subscription, db: Session) -> float:
+        \"\"\"Calculate churn probability for a subscription.\"\"\"
+        risk_score = 0.0
+
+        user = db.query(User).filter(User.id == subscription.user_id).first()
+
+        # Factor 1: Login frequency
+        if user.last_login:
+            days_since_login = (datetime.utcnow() - user.last_login).days
+            if days_since_login > 30:
+                risk_score += 0.4
+            elif days_since_login > 14:
+                risk_score += 0.2
+
+        # Factor 2: Usage (businesses created)
+        business_count = db.query(Business).filter(Business.user_id == user.id).count()
+        if business_count == 0:
+            risk_score += 0.3
+        elif business_count == 1:
+            risk_score += 0.1
+
+        # Factor 3: Cancel at period end flag
+        if subscription.cancel_at_period_end:
+            risk_score += 0.5
+
+        return min(risk_score, 1.0)
+"""
+
+new_calculate_churn_risk = """
+    def _calculate_churn_risk(self, subscription: Subscription, user: User, business_count: int) -> float:
+        \"\"\"Calculate churn probability for a subscription.\"\"\"
+        risk_score = 0.0
+
+        # Factor 1: Login frequency
+        if user.last_login:
+            days_since_login = (datetime.utcnow() - user.last_login).days
+            if days_since_login > 30:
+                risk_score += 0.4
+            elif days_since_login > 14:
+                risk_score += 0.2
+
+        # Factor 2: Usage (businesses created)
+        if business_count == 0:
+            risk_score += 0.3
+        elif business_count == 1:
+            risk_score += 0.1
+
+        # Factor 3: Cancel at period end flag
+        if subscription.cancel_at_period_end:
+            risk_score += 0.5
+
+        return min(risk_score, 1.0)
+"""
+
+content = content.replace(old_calculate_churn_risk.strip("\n"), new_calculate_churn_risk.strip("\n"))
+
+with open("src/blank_business_builder/level6_agent.py", "w") as f:
+    f.write(content)

--- a/src/blank_business_builder/level6_agent.py
+++ b/src/blank_business_builder/level6_agent.py
@@ -12,6 +12,7 @@ from enum import Enum
 import json
 from dataclasses import dataclass
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 
 from .database import User, Business, MarketingCampaign, Subscription
 from .integrations import IntegrationFactory
@@ -273,21 +274,39 @@ class Level6Agent:
             Subscription.status == "active"
         ).all()
 
+        if not subscriptions:
+            return decisions
+
+        # Bulk fetch users
+        user_ids = [sub.user_id for sub in subscriptions]
+        users = db.query(User).filter(User.id.in_(user_ids)).all()
+        user_dict = {user.id: user for user in users}
+
+        # Bulk fetch business counts
+        business_counts = dict(
+            db.query(Business.user_id, func.count(Business.id))
+            .filter(Business.user_id.in_(user_ids))
+            .group_by(Business.user_id)
+            .all()
+        )
+
         for subscription in subscriptions:
-            churn_risk = self._calculate_churn_risk(subscription, db)
+            user = user_dict.get(subscription.user_id)
+            if not user:
+                continue
+
+            business_count = business_counts.get(subscription.user_id, 0)
+            churn_risk = self._calculate_churn_risk(subscription, user, business_count)
 
             if churn_risk > 0.7:  # High risk
-                user = db.query(User).filter(User.id == subscription.user_id).first()
                 decision = await self._create_retention_campaign(user, churn_risk, db)
                 decisions.append(decision)
 
         return decisions
 
-    def _calculate_churn_risk(self, subscription: Subscription, db: Session) -> float:
+    def _calculate_churn_risk(self, subscription: Subscription, user: User, business_count: int) -> float:
         """Calculate churn probability for a subscription."""
         risk_score = 0.0
-
-        user = db.query(User).filter(User.id == subscription.user_id).first()
 
         # Factor 1: Login frequency
         if user.last_login:
@@ -298,7 +317,6 @@ class Level6Agent:
                 risk_score += 0.2
 
         # Factor 2: Usage (businesses created)
-        business_count = db.query(Business).filter(Business.user_id == user.id).count()
         if business_count == 0:
             risk_score += 0.3
         elif business_count == 1:

--- a/tests/benchmark_churn_prevention.py
+++ b/tests/benchmark_churn_prevention.py
@@ -1,0 +1,90 @@
+import asyncio
+import time
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from src.blank_business_builder.database import Base, User, Subscription, Business
+from src.blank_business_builder.level6_agent import Level6Agent, AutonomyLevel
+import uuid
+from datetime import datetime, timedelta
+
+def setup_test_db(num_users=3000):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    print(f"Generating {num_users} users, subscriptions, and businesses...")
+    users = []
+    subscriptions = []
+    businesses = []
+
+    now = datetime.utcnow()
+
+    for i in range(num_users):
+        user_id = uuid.uuid4()
+        user = User(
+            id=user_id,
+            email=f"user{i}@example.com",
+            hashed_password="hash",
+            last_login=now - timedelta(days=(i % 40)) # mix of active and inactive
+        )
+        users.append(user)
+
+        subscription = Subscription(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            status="active",
+            plan_name="pro"
+        )
+        subscriptions.append(subscription)
+
+        num_businesses = i % 3
+        for j in range(num_businesses):
+            business = Business(
+                id=uuid.uuid4(),
+                user_id=user_id,
+                business_name=f"Business {i}-{j}",
+                status="active"
+            )
+            businesses.append(business)
+
+    db.bulk_save_objects(users)
+    db.bulk_save_objects(subscriptions)
+    db.bulk_save_objects(businesses)
+    db.commit()
+
+    return db
+
+async def run_benchmark():
+    db = setup_test_db(num_users=3000)
+    agent = Level6Agent(autonomy_level=AutonomyLevel.FULL)
+
+    # Mocking external calls to avoid SendGrid/OpenAI
+    class MockService:
+        def generate_email_campaign(self, *args, **kwargs):
+            return {"subject": "subject", "body": "body"}
+        def send_email(self, *args, **kwargs):
+            pass
+
+    agent.openai = MockService()
+    agent.sendgrid = MockService()
+
+    print("Running baseline benchmark...")
+
+    # warmup
+    await agent.manage_churn_prevention(db)
+
+    start_time = time.time()
+
+    decisions = await agent.manage_churn_prevention(db)
+
+    end_time = time.time()
+    duration = end_time - start_time
+
+    print(f"Processed {len(decisions)} churn prevention decisions.")
+    print(f"Execution time: {duration:.4f} seconds")
+
+    db.close()
+
+if __name__ == "__main__":
+    asyncio.run(run_benchmark())


### PR DESCRIPTION
💡 **What:** Refactored `manage_churn_prevention` to execute exactly two pre-fetch bulk queries up front using `user_ids`. First, a `.filter(User.id.in_(user_ids))` fetches all User objects into a dictionary. Second, a `.group_by(Business.user_id).filter(Business.user_id.in_(user_ids))` fetches all the business counts at once into a dictionary. Then updated `_calculate_churn_risk` to accept these pre-fetched values.
🎯 **Why:** It resolves a severe N+1 problem. Previously, computing churn for 1,000 active subscriptions would result in 2,000 separate DB queries sequentially executing. Now it requires only 3 queries total (1 to get subscriptions, 1 to get users, 1 to get counts), regardless of how many subscribers exist.
📊 **Measured Improvement:** Baseline execution time for 3,000 users was 3.4879 seconds. Optimized execution time is 0.2035 seconds, resulting in a >17x performance improvement.

---
*PR created automatically by Jules for task [9700439927734211103](https://jules.google.com/task/9700439927734211103) started by @Workofarttattoo*