### PR TITLE
Fix: Configure uvicorn to use DEBUG environment variable for reload

### DIFF
--- a/src/blank_business_builder/__main__.py
+++ b/src/blank_business_builder/__main__.py
@@ -2,6 +2,7 @@
 Better Business Builder - Entry point for module execution
 Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights Reserved. PATENT PENDING.
 """
+import os
 import uvicorn
 
 if __name__ == "__main__":
@@ -9,5 +10,5 @@ if __name__ == "__main__":
         "blank_business_builder.main:app",
         host="0.0.0.0",
         port=8000,
-        reload=True
+        reload=os.getenv('DEBUG', 'false').lower() == 'true'
     )


### PR DESCRIPTION
Changes `uvicorn.run()` to use `reload=os.getenv('DEBUG', 'false').lower() == 'true'` instead of hardcoding `reload=True`. This prevents the application from automatically reloading in production environments where `DEBUG` is not set.

**Changes made:**
- Imported `os` in `src/blank_business_builder/__main__.py`.
- Replaced `reload=True` with `reload=os.getenv('DEBUG', 'false').lower() == 'true'` inside the `uvicorn.run` call.

---
*PR created automatically by Jules for task [12457714988761496280](https://jules.google.com/task/12457714988761496280) started by @Workofarttattoo*