### PR TITLE
Add PaymentTransaction model

### DIFF
--- a/src/blank_business_builder/database.py
+++ b/src/blank_business_builder/database.py
@@ -90,6 +90,7 @@ class User(Base):
     businesses = relationship("Business", back_populates="user", cascade="all, delete-orphan")
     subscriptions = relationship("Subscription", back_populates="user", cascade="all, delete-orphan")
     api_integrations = relationship("APIIntegration", back_populates="user", cascade="all, delete-orphan")
+    payment_transactions = relationship("PaymentTransaction", back_populates="user", cascade="all, delete-orphan")
 
     def __repr__(self):
         return f"<User(id={self.id}, email={self.email}, tier={self.subscription_tier})>"
@@ -234,6 +235,27 @@ class AuditLog(Base):
 
     def __repr__(self):
         return f"<AuditLog(id={self.id}, action={self.action}, timestamp={self.timestamp})>"
+
+
+class PaymentTransaction(Base):
+    """Payment transaction model"""
+    __tablename__ = 'payment_transactions'
+
+    id = Column(UUIDType(), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUIDType(), ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True)
+    stripe_payment_intent_id = Column(String(255), unique=True, index=True, nullable=False)
+    amount = Column(Numeric(12, 2), nullable=False)
+    currency = Column(String(10), nullable=False)
+    status = Column(String(50), default='pending')  # pending, succeeded, failed
+    description = Column(Text, nullable=True)
+    transaction_metadata = Column(JSONType(), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    # Relationships
+    user = relationship("User", back_populates="payment_transactions")
+
+    def __repr__(self):
+        return f"<PaymentTransaction(id={self.id}, user_id={self.user_id}, amount={self.amount}, status={self.status})>"
 
 
 class Subscription(Base):

--- a/src/blank_business_builder/payments.py
+++ b/src/blank_business_builder/payments.py
@@ -375,7 +375,7 @@ class PaymentEventHandler:
             currency=payment_intent["currency"].upper(),
             status="succeeded",
             description=payment_intent.get("description", "Payment"),
-            metadata=payment_intent.get("metadata", {})
+            transaction_metadata=payment_intent.get("metadata", {})
         )
         db.add(transaction)
         db.commit()
@@ -404,7 +404,7 @@ class PaymentEventHandler:
             currency=payment_intent["currency"].upper(),
             status="failed",
             description=payment_intent.get("description", "Payment"),
-            metadata=payment_intent.get("metadata", {})
+            transaction_metadata=payment_intent.get("metadata", {})
         )
         db.add(transaction)
         db.commit()

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -221,3 +221,36 @@ class TestStripeService:
 
         assert exc_info.value.status_code == 400
         assert "Invalid payload" in exc_info.value.detail
+
+    @patch("src.blank_business_builder.database.PaymentTransaction")
+    def test_handle_payment_succeeded(self, mock_transaction):
+        from src.blank_business_builder.payments import StripeService, PaymentEventHandler
+        from src.blank_business_builder.database import User
+        mock_db = MagicMock()
+        mock_user = User(id="user_id", stripe_customer_id="cust_123")
+        mock_db.query().filter().first.return_value = mock_user
+
+        event_data = {
+            "object": {
+                "id": "pi_123",
+                "customer": "cust_123",
+                "amount": 1000,
+                "currency": "usd",
+                "description": "Test Payment",
+                "metadata": {"key": "value"}
+            }
+        }
+
+        PaymentEventHandler.handle_payment_succeeded(event_data, mock_db)
+
+        mock_transaction.assert_called_once_with(
+            user_id="user_id",
+            stripe_payment_intent_id="pi_123",
+            amount=10.0,
+            currency="USD",
+            status="succeeded",
+            description="Test Payment",
+            transaction_metadata={"key": "value"}
+        )
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()


### PR DESCRIPTION
Added `PaymentTransaction` model to `src/blank_business_builder/database.py` per instructions. 
Renamed the generic column name `metadata` to `transaction_metadata` to bypass SQLAlchemy's `InvalidRequestError` reserved attribute error. 
Updated `src/blank_business_builder/payments.py` to correctly map the `transaction_metadata` field upon instantiation and created test coverage verifying `PaymentTransaction` creation in `tests/test_payments.py`.

---
*PR created automatically by Jules for task [7075007288541449144](https://jules.google.com/task/7075007288541449144) started by @Workofarttattoo*