### PR TITLE
Update OpenAI API calls to v1.0 client pattern

### DIFF
--- a/src/blank_business_builder/integrations.py
+++ b/src/blank_business_builder/integrations.py
@@ -55,16 +55,23 @@ if openai is None:  # pragma: no cover
         def __init__(self, content: str):
             self.message = type("Message", (), {"content": content})
 
-    class _OpenAIChatCompletion:
+    class _OpenAIChatCompletions:
         @staticmethod
         def create(**kwargs):
             prompt = kwargs.get("messages", [{}])[-1].get("content", "Default response")
             fallback = json.dumps({"raw_content": prompt})
             return type("Completion", (), {"choices": [_OpenAIChatChoice(fallback)]})
 
+    class _OpenAIChat:
+        completions = _OpenAIChatCompletions()
+
+    class _OpenAIClientStub:
+        def __init__(self, api_key: str = ""):
+            self.api_key = api_key
+            self.chat = _OpenAIChat()
+
     class _OpenAIStub:
-        api_key = ""
-        ChatCompletion = _OpenAIChatCompletion
+        OpenAI = _OpenAIClientStub
 
     openai = _OpenAIStub()
 
@@ -132,7 +139,6 @@ class OpenAIService:
 
     def __init__(self):
         self.api_key = os.getenv("OPENAI_API_KEY", "")
-        openai.api_key = self.api_key
         self.model = os.getenv("OPENAI_MODEL", "gpt-4")
 
     def generate_business_plan(
@@ -169,7 +175,8 @@ class OpenAIService:
         )
 
         try:
-            response = openai.ChatCompletion.create(
+            client = openai.OpenAI(api_key=self.api_key)
+            response = client.chat.completions.create(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system_prompt},
@@ -230,7 +237,8 @@ class OpenAIService:
         )
 
         try:
-            response = openai.ChatCompletion.create(
+            client = openai.OpenAI(api_key=self.api_key)
+            response = client.chat.completions.create(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system_prompt},
@@ -276,7 +284,8 @@ class OpenAIService:
         )
 
         try:
-            response = openai.ChatCompletion.create(
+            client = openai.OpenAI(api_key=self.api_key)
+            response = client.chat.completions.create(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system_prompt},
@@ -325,7 +334,8 @@ class OpenAIService:
         user_content = json.dumps({"competitor_name": competitor_name, "industry": industry})
 
         try:
-            response = openai.ChatCompletion.create(
+            client = openai.OpenAI(api_key=self.api_key)
+            response = client.chat.completions.create(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system_prompt},

--- a/tests/test_integrations_queue.py
+++ b/tests/test_integrations_queue.py
@@ -50,8 +50,9 @@ class TestIntegrationsQueue(unittest.TestCase):
             self.assertEqual(payload['to_email'], "test@example.com")
 
     def test_buffer_create_post_queues_task(self):
+        import asyncio
         service = BufferService()
-        result = service.create_post("profile_123", "Hello World")
+        result = asyncio.run(service.create_post("profile_123", "Hello World"))
         self.assertTrue(result['success'])
 
         # Check queue


### PR DESCRIPTION
Updated the `openai.ChatCompletion.create()` calls inside `src/blank_business_builder/integrations.py` to use the v1.0+ client instantiation pattern: `client = openai.OpenAI(api_key=self.api_key)` then `client.chat.completions.create(...)`. Also updated the module stub class for test simulations to match the new nested layout without regressions.

---
*PR created automatically by Jules for task [3611171169791210204](https://jules.google.com/task/3611171169791210204) started by @Workofarttattoo*