### PR TITLE
Fix recursive UUIDType descriptor in database.py

### DIFF
--- a/src/blank_business_builder/database.py
+++ b/src/blank_business_builder/database.py
@@ -24,7 +24,7 @@ class UUIDType(TypeDecorator):
     def load_dialect_impl(self, dialect):
         if dialect.name == "sqlite":
             return dialect.type_descriptor(String(36))
-        return dialect.type_descriptor(UUIDType())
+        return dialect.type_descriptor(UUID(as_uuid=True))
 
     def process_bind_param(self, value, dialect):
         if value is None:


### PR DESCRIPTION
This PR fixes a bug in `src/blank_business_builder/database.py` line 27 where the `UUIDType` class incorrectly returned `UUIDType()` inside `load_dialect_impl`, causing infinite recursion. It now properly returns `UUID(as_uuid=True)`.

---
*PR created automatically by Jules for task [6355840291244911902](https://jules.google.com/task/6355840291244911902) started by @Workofarttattoo*