### PR TITLE
⚡ Bolt: [performance] Optimize get_db to use connection pool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+## 2026-04-11 - Database Connection Pooling Optimization
+**Learning:** In FastAPI, defining `engine = create_engine()` inside a dependency `yield` function like `get_db()` causes the application to create a new database connection pool on every single request. This is a severe performance anti-pattern that exhausts database connections and slows down all routes.
+**Action:** Always instantiate SQLAlchemy engines and session makers globally or lazily cache them so they are reused across requests.

--- a/src/blank_business_builder/database.py
+++ b/src/blank_business_builder/database.py
@@ -363,12 +363,19 @@ def drop_db(database_url: Optional[str] = None):
     return engine
 
 
+_engine = None
+_SessionLocal = None
+
 # Dependency for FastAPI
 def get_db():
     """FastAPI dependency for database sessions"""
-    engine = get_db_engine()
-    Session = get_session_maker(engine)
-    session = Session()
+    global _engine, _SessionLocal
+    if _engine is None:
+        _engine = get_db_engine()
+    if _SessionLocal is None:
+        _SessionLocal = get_session_maker(_engine)
+
+    session = _SessionLocal()
     try:
         yield session
     finally:


### PR DESCRIPTION
💡 What: Optimized the `get_db` FastAPI dependency in `src/blank_business_builder/database.py` to lazily cache the SQLAlchemy `engine` and `sessionmaker` globally.

🎯 Why: Previously, `get_db` created a new engine and session factory on every single request. This is a severe anti-pattern that completely bypassed database connection pooling, resulting in high latency and database strain under load.

📊 Impact: Reduces database connection overhead to nearly zero per request, enabling the app to handle significantly higher concurrency.

🔬 Measurement: Local tests (`pytest tests/test_database.py`) verify the database connection still operates as expected. Benchmarks under load will demonstrate massive improvements in response times.

---
*PR created automatically by Jules for task [9815087397595414270](https://jules.google.com/task/9815087397595414270) started by @Workofarttattoo*