### PR TITLE
⚡ Bolt: [performance improvement] fix N+1 query in manage_marketing_campaigns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+
+## 2026-04-14 - Fix N+1 query in manage_marketing_campaigns
+**Learning:** In Level6Agent.manage_marketing_campaigns, looping over businesses and querying for their individual recent marketing campaigns creates an N+1 performance bottleneck. Eager loading could cause OOM issues with large campaign histories.
+**Action:** Used an efficient LEFT OUTER JOIN to perform this check at the database level instead, cutting queries from O(N) to O(1).

--- a/src/blank_business_builder/level6_agent.py
+++ b/src/blank_business_builder/level6_agent.py
@@ -445,12 +445,21 @@ class Level6Agent:
         decisions = []
 
         # Auto-generate marketing campaigns for businesses without recent campaigns
-        businesses = db.query(Business).filter(Business.status == "active").all()
+        # Optimization: Use a single LEFT OUTER JOIN query to prevent N+1 queries
+        thirty_days_ago = datetime.utcnow() - timedelta(days=30)
 
-        for business in businesses:
-            if self._needs_marketing_campaign(business, db):
-                decision = await self._create_auto_campaign(business, db)
-                decisions.append(decision)
+        businesses_without_recent_campaigns = db.query(Business).outerjoin(
+            MarketingCampaign,
+            (Business.id == MarketingCampaign.business_id) &
+            (MarketingCampaign.created_at > thirty_days_ago)
+        ).filter(
+            Business.status == "active",
+            MarketingCampaign.id == None
+        ).all()
+
+        for business in businesses_without_recent_campaigns:
+            decision = await self._create_auto_campaign(business, db)
+            decisions.append(decision)
 
         return decisions
 


### PR DESCRIPTION
💡 What: Optimized marketing campaign check. 🎯 Why: Fixes N+1 query problem. 📊 Impact: O(1) queries instead of O(N). 🔬 Measurement: Benchmarked query count dropped from N+1 to 1.

---
*PR created automatically by Jules for task [16005703731790693940](https://jules.google.com/task/16005703731790693940) started by @Workofarttattoo*