### PR TITLE
⚡ Bolt: Cache SQLAlchemy engine globally to fix connection pooling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+## 2026-03-05 - Fix Connection Pooling in Database Dependencies
+**Learning:** Found that recreating `engine` and `sessionmaker` inside FastAPI dependencies like `get_db()` on every request completely defeats connection pooling, as a new connection pool is created each time. This causes severe performance regressions and exhausts database connections under load.
+**Action:** Always lazily cache SQLAlchemy engines and session makers as module-level global variables (`_engine = None`, `_SessionLocal = None`) to ensure the connection pool is preserved and reused across requests.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,3 +1,13 @@
-🎯 **What:** Adds unit tests for the asynchronous `run_autonomous_loop` and `launch_magic_rd_lab_business` functions in `magic_rd_lab_autonomous_agents.py`. The infinite loop and sleeping functionality are mocked to allow fast, deterministic tests without running into timeout issues.
-📊 **Coverage:** Covered loop entry, loop exit conditions via mocked exceptions, agent deployments, invocation of underlying methods, and ensuring metrics sum exactly appropriately after 1 pass through the loop.
-✨ **Result:** Enhanced test coverage that protects core async loop functionality from regressions.
+💡 What:
+Cached the SQLAlchemy engine and session maker instances as module-level globals in `src/blank_business_builder/database.py`. The FastAPI dependency `get_db()` now lazily initializes and reuses these instances instead of creating new ones on every request.
+
+🎯 Why:
+The previous implementation of `get_db()` called `get_db_engine()` and `get_session_maker()` on every single request. This completely defeats SQLAlchemy's built-in connection pooling, as a new connection pool is created each time. Under high load, this causes severe performance regressions and exhausts database connections.
+
+📊 Impact:
+- **Reduces database connection overhead** to nearly zero per request after initial setup.
+- **Prevents database connection exhaustion** by properly utilizing SQLAlchemy's connection pool.
+- **Improves overall request latency** for any endpoint interacting with the database.
+
+🔬 Measurement:
+To verify the improvement, you can monitor the active database connections using `pg_stat_activity` while load testing endpoints that use the `get_db` dependency. The number of connections should remain stable (capped by `pool_size` + `max_overflow`), whereas previously it would spike significantly.

--- a/src/blank_business_builder/database.py
+++ b/src/blank_business_builder/database.py
@@ -363,12 +363,18 @@ def drop_db(database_url: Optional[str] = None):
     return engine
 
 
+_engine = None
+_SessionLocal = None
+
 # Dependency for FastAPI
 def get_db():
     """FastAPI dependency for database sessions"""
-    engine = get_db_engine()
-    Session = get_session_maker(engine)
-    session = Session()
+    global _engine, _SessionLocal
+    if _engine is None:
+        _engine = get_db_engine()
+        _SessionLocal = get_session_maker(_engine)
+
+    session = _SessionLocal()
     try:
         yield session
     finally:


### PR DESCRIPTION
💡 What:
Cached the SQLAlchemy engine and session maker instances as module-level globals in `src/blank_business_builder/database.py`. The FastAPI dependency `get_db()` now lazily initializes and reuses these instances instead of creating new ones on every request.

🎯 Why:
The previous implementation of `get_db()` called `get_db_engine()` and `get_session_maker()` on every single request. This completely defeats SQLAlchemy's built-in connection pooling, as a new connection pool is created each time. Under high load, this causes severe performance regressions and exhausts database connections.

📊 Impact:
- **Reduces database connection overhead** to nearly zero per request after initial setup.
- **Prevents database connection exhaustion** by properly utilizing SQLAlchemy's connection pool.
- **Improves overall request latency** for any endpoint interacting with the database.

🔬 Measurement:
To verify the improvement, you can monitor the active database connections using `pg_stat_activity` while load testing endpoints that use the `get_db` dependency. The number of connections should remain stable (capped by `pool_size` + `max_overflow`), whereas previously it would spike significantly.

---
*PR created automatically by Jules for task [12784472228333488241](https://jules.google.com/task/12784472228333488241) started by @Workofarttattoo*