### PR TITLE
Fix Kubernetes deployment configuration

### DIFF
--- a/.github/workflows/kubernetes-auto-deploy.yml
+++ b/.github/workflows/kubernetes-auto-deploy.yml
@@ -1,0 +1,294 @@
+# Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights Reserved. PATENT PENDING.
+#
+# Build and deploy BBB to Kubernetes.
+
+name: Kubernetes Auto Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "GitHub environment to deploy"
+        required: true
+        default: production
+        type: choice
+        options:
+          - production
+          - staging
+      namespace:
+        description: "Kubernetes namespace"
+        required: true
+        default: bbb-production
+      deploy_ingress:
+        description: "Apply k8s/ingress.yaml"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: kubernetes-${{ github.event.inputs.environment || 'production' }}
+  cancel-in-progress: false
+
+env:
+  K8S_NAMESPACE: ${{ github.event.inputs.namespace || 'bbb-production' }}
+  DEPLOY_ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
+
+jobs:
+  deploy:
+    name: Build and deploy to Kubernetes
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'production' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare image name
+        id: image
+        run: |
+          set -euo pipefail
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          image_name="ghcr.io/${owner}/bbb-api"
+          echo "IMAGE_NAME=${image_name}" >> "${GITHUB_ENV}"
+          echo "image_name=${image_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push BBB API image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image_name }}:${{ github.sha }}
+            ${{ steps.image.outputs.image_name }}:${{ env.DEPLOY_ENVIRONMENT }}-latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        env:
+          KUBE_CONFIG_PRODUCTION: ${{ secrets.KUBE_CONFIG_PRODUCTION }}
+          KUBE_CONFIG_STAGING: ${{ secrets.KUBE_CONFIG_STAGING }}
+          KUBE_CONFIG_FALLBACK: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: |
+          set -euo pipefail
+          case "${DEPLOY_ENVIRONMENT}" in
+            production)
+              KUBE_CONFIG_B64="${KUBE_CONFIG_PRODUCTION:-${KUBE_CONFIG_FALLBACK:-}}"
+              ;;
+            staging)
+              KUBE_CONFIG_B64="${KUBE_CONFIG_STAGING:-${KUBE_CONFIG_FALLBACK:-}}"
+              ;;
+            *)
+              echo "Unsupported deployment environment: ${DEPLOY_ENVIRONMENT}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${KUBE_CONFIG_B64}" ]; then
+            echo "Missing kubeconfig secret for ${DEPLOY_ENVIRONMENT}" >&2
+            exit 1
+          fi
+          mkdir -p "${HOME}/.kube"
+          echo "${KUBE_CONFIG_B64}" | base64 -d > "${HOME}/.kube/config"
+          chmod 600 "${HOME}/.kube/config"
+
+      - name: Validate deployment secrets
+        env:
+          BBB_JWT_SECRET_KEY: ${{ secrets.BBB_JWT_SECRET_KEY }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in BBB_JWT_SECRET_KEY POSTGRES_PASSWORD REDIS_PASSWORD ENCRYPTION_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required GitHub secret: ${name}" >&2
+              missing=1
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Validate Kubernetes access
+        run: |
+          set -euo pipefail
+          kubectl version --client=true
+          kubectl cluster-info
+
+      - name: Apply namespace, config, and secrets
+        env:
+          BBB_JWT_SECRET_KEY: ${{ secrets.BBB_JWT_SECRET_KEY }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          STRIPE_PROFESSIONAL_PRICE_ID: ${{ secrets.STRIPE_PROFESSIONAL_PRICE_ID }}
+          STRIPE_ENTERPRISE_PRICE_ID: ${{ secrets.STRIPE_ENTERPRISE_PRICE_ID }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4' }}
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          SENDGRID_FROM_EMAIL: ${{ vars.SENDGRID_FROM_EMAIL || 'noreply@betterbusinessbuilder.com' }}
+          BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+          AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
+          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
+        run: |
+          set -euo pipefail
+          kubectl apply -f k8s/namespace.yaml
+          kubectl apply -f k8s/configmap.yaml
+
+          kubectl create secret generic bbb-secrets \
+            --namespace="${K8S_NAMESPACE}" \
+            --from-literal=JWT_SECRET_KEY="${BBB_JWT_SECRET_KEY}" \
+            --from-literal=STRIPE_SECRET_KEY="${STRIPE_SECRET_KEY}" \
+            --from-literal=STRIPE_WEBHOOK_SECRET="${STRIPE_WEBHOOK_SECRET}" \
+            --from-literal=STRIPE_PROFESSIONAL_PRICE_ID="${STRIPE_PROFESSIONAL_PRICE_ID}" \
+            --from-literal=STRIPE_ENTERPRISE_PRICE_ID="${STRIPE_ENTERPRISE_PRICE_ID}" \
+            --from-literal=OPENAI_API_KEY="${OPENAI_API_KEY}" \
+            --from-literal=OPENAI_MODEL="${OPENAI_MODEL}" \
+            --from-literal=SENDGRID_API_KEY="${SENDGRID_API_KEY}" \
+            --from-literal=SENDGRID_FROM_EMAIL="${SENDGRID_FROM_EMAIL}" \
+            --from-literal=BUFFER_ACCESS_TOKEN="${BUFFER_ACCESS_TOKEN}" \
+            --from-literal=AUTH0_DOMAIN="${AUTH0_DOMAIN}" \
+            --from-literal=AUTH0_CLIENT_ID="${AUTH0_CLIENT_ID}" \
+            --from-literal=AUTH0_CLIENT_SECRET="${AUTH0_CLIENT_SECRET}" \
+            --from-literal=AUTH0_AUDIENCE="${AUTH0_AUDIENCE}" \
+            --from-literal=ENCRYPTION_KEY="${ENCRYPTION_KEY}" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+          kubectl create secret generic postgres-credentials \
+            --namespace="${K8S_NAMESPACE}" \
+            --from-literal=password="${POSTGRES_PASSWORD}" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+          kubectl create secret generic redis-credentials \
+            --namespace="${K8S_NAMESPACE}" \
+            --from-literal=password="${REDIS_PASSWORD}" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+      - name: Configure GHCR image pull secret
+        env:
+          GHCR_PULL_USERNAME: ${{ secrets.GHCR_PULL_USERNAME || github.actor }}
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          kubectl create secret docker-registry ghcr-pull-secret \
+            --namespace="${K8S_NAMESPACE}" \
+            --docker-server=ghcr.io \
+            --docker-username="${GHCR_PULL_USERNAME}" \
+            --docker-password="${GHCR_PULL_TOKEN}" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+          kubectl patch serviceaccount default \
+            -n "${K8S_NAMESPACE}" \
+            --type=merge \
+            -p '{"imagePullSecrets":[{"name":"ghcr-pull-secret"}]}'
+
+      - name: Deploy data services
+        run: |
+          set -euo pipefail
+          kubectl apply -f k8s/postgres.yaml
+          kubectl apply -f k8s/redis.yaml
+          kubectl wait --for=condition=ready pod \
+            -l app=postgres \
+            -n "${K8S_NAMESPACE}" \
+            --timeout=5m
+          kubectl wait --for=condition=ready pod \
+            -l app=redis \
+            -n "${K8S_NAMESPACE}" \
+            --timeout=5m
+
+      - name: Run database migrations
+        run: |
+          set -euo pipefail
+          kubectl delete job bbb-migrations \
+            -n "${K8S_NAMESPACE}" \
+            --ignore-not-found
+
+          cat <<EOF | kubectl apply -f -
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: bbb-migrations
+            namespace: ${K8S_NAMESPACE}
+          spec:
+            backoffLimit: 1
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                - name: migrations
+                  image: ${IMAGE_NAME}:${GITHUB_SHA}
+                  imagePullPolicy: Always
+                  command: ["alembic", "upgrade", "head"]
+                  env:
+                  - name: DATABASE_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: postgres-credentials
+                        key: password
+                  - name: DATABASE_URL
+                    value: "postgresql://bbbuser:\$(DATABASE_PASSWORD)@postgres:5432/bbb_production"
+          EOF
+
+          if ! kubectl wait --for=condition=complete job/bbb-migrations \
+            -n "${K8S_NAMESPACE}" \
+            --timeout=5m; then
+            kubectl logs job/bbb-migrations -n "${K8S_NAMESPACE}" || true
+            exit 1
+          fi
+          kubectl logs job/bbb-migrations -n "${K8S_NAMESPACE}" || true
+
+      - name: Deploy BBB application
+        run: |
+          set -euo pipefail
+          kubectl apply -f k8s/deployment.yaml
+          kubectl set image deployment/bbb-api \
+            api="${IMAGE_NAME}:${GITHUB_SHA}" \
+            -n "${K8S_NAMESPACE}"
+          kubectl rollout status deployment/bbb-api \
+            -n "${K8S_NAMESPACE}" \
+            --timeout=10m
+
+      - name: Apply ingress
+        if: ${{ github.event_name == 'push' || inputs.deploy_ingress }}
+        run: |
+          set -euo pipefail
+          kubectl apply -f k8s/ingress.yaml
+
+      - name: Show deployed resources
+        if: always()
+        run: |
+          kubectl get deployment,service,hpa,ingress \
+            -n "${K8S_NAMESPACE}" \
+            -l app=bbb-api || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN pip install --upgrade pip && \
 
 # Copy application code
 COPY src/ ./src/
+COPY static/ ./static/
+COPY data/ ./data/
+COPY docs/architecture/PHASE_2_COMPLETE.md ./docs/architecture/PHASE_2_COMPLETE.md
 COPY pyproject.toml .
 COPY README.md .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN pip install --upgrade pip && \
 COPY src/ ./src/
 COPY static/ ./static/
 COPY data/ ./data/
+RUN mkdir -p ./docs/architecture
 COPY docs/architecture/PHASE_2_COMPLETE.md ./docs/architecture/PHASE_2_COMPLETE.md
 COPY pyproject.toml .
 COPY README.md .

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -44,6 +44,10 @@ Or apply the template (after replacing CHANGEME values):
 kubectl apply -f k8s/secrets.yaml
 ```
 
+Postgres and Redis credentials are intentionally created separately from
+`k8s/postgres.yaml` and `k8s/redis.yaml` so updating the data-service manifests
+does not overwrite real passwords.
+
 ### 3. Apply ConfigMap
 
 ```bash
@@ -163,6 +167,39 @@ kubectl rollout status deployment/bbb-api -n bbb-production
 ```bash
 kubectl rollout undo deployment/bbb-api -n bbb-production
 ```
+
+## Automatic GitHub Actions Deployment
+
+The `Kubernetes Auto Deploy` workflow builds the Docker image, pushes it to
+GitHub Container Registry, applies the Kubernetes manifests, runs database
+migrations, updates the `bbb-api` Deployment image, and waits for rollout.
+
+Required repository secrets:
+
+| Secret | Description |
+| --- | --- |
+| `KUBE_CONFIG_PRODUCTION` | Base64-encoded kubeconfig with access to the production cluster. |
+| `KUBE_CONFIG_STAGING` | Base64-encoded kubeconfig for manual staging deploys, if used. |
+| `BBB_JWT_SECRET_KEY` | JWT signing secret for the API. |
+| `POSTGRES_PASSWORD` | Password for the in-cluster `postgres-credentials` secret. |
+| `REDIS_PASSWORD` | Password for the in-cluster `redis-credentials` secret. |
+| `STRIPE_SECRET_KEY` | Stripe secret key. |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret. |
+| `OPENAI_API_KEY` | OpenAI API key. |
+| `SENDGRID_API_KEY` | SendGrid API key. |
+| `BUFFER_ACCESS_TOKEN` | Buffer API token. |
+| `ENCRYPTION_KEY` | Application encryption key. |
+| `GHCR_PULL_TOKEN` | Optional token with package read access if the cluster cannot pull with the workflow token. |
+
+Optional repository variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENAI_MODEL` | `gpt-4` | Model name stored in `bbb-secrets`. |
+| `SENDGRID_FROM_EMAIL` | `noreply@betterbusinessbuilder.com` | Sender email stored in `bbb-secrets`. |
+
+Run automatically on pushes to `main`, or manually from GitHub Actions via
+`workflow_dispatch`.
 
 ### Update ConfigMap or Secrets
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -71,9 +71,11 @@ kubectl run -it --rm migrations \
   --image=bbb/api:latest \
   --restart=Never \
   --namespace=bbb-production \
-  --env="DATABASE_URL=$(kubectl get secret bbb-secrets -n bbb-production -o jsonpath='{.data.DATABASE_URL}' | base64 -d)" \
+  --env="DATABASE_URL=postgresql://bbbuser:$(kubectl get secret postgres-credentials -n bbb-production -o jsonpath='{.data.password}' | base64 -d)@postgres:5432/bbb_production" \
   -- alembic upgrade head
 ```
+
+Use the same image tag here that you deploy in `k8s/deployment.yaml`.
 
 ### 6. Deploy Application
 
@@ -146,11 +148,11 @@ kubectl get hpa bbb-api-hpa -n bbb-production --watch
 
 ```bash
 # Build and push new image
-docker build -t bbb/api:v1.1.0 .
-docker push bbb/api:v1.1.0
+docker build -t <registry>/bbb-api:v1.1.0 .
+docker push <registry>/bbb-api:v1.1.0
 
 # Update deployment
-kubectl set image deployment/bbb-api api=bbb/api:v1.1.0 -n bbb-production
+kubectl set image deployment/bbb-api api=<registry>/bbb-api:v1.1.0 -n bbb-production
 
 # Monitor rollout
 kubectl rollout status deployment/bbb-api -n bbb-production

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -40,30 +40,31 @@ spec:
         - containerPort: 8000
           name: http
           protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: bbb-config
         env:
-        # From ConfigMap
-        - name: APP_NAME
+        - name: DATABASE_PASSWORD
           valueFrom:
-            configMapKeyRef:
-              name: bbb-config
-              key: APP_NAME
-        - name: LOG_LEVEL
+            secretKeyRef:
+              name: postgres-credentials
+              key: password
+        - name: REDIS_PASSWORD
           valueFrom:
-            configMapKeyRef:
-              name: bbb-config
-              key: LOG_LEVEL
-        - name: API_PORT
-          valueFrom:
-            configMapKeyRef:
-              name: bbb-config
-              key: API_PORT
-
-        # From Secrets
+            secretKeyRef:
+              name: redis-credentials
+              key: password
         - name: DATABASE_URL
+          value: "postgresql://bbbuser:$(DATABASE_PASSWORD)@postgres:5432/bbb_production"
+        - name: REDIS_URL
+          value: "redis://:$(REDIS_PASSWORD)@redis:6379/0"
+        - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: bbb-secrets
-              key: DATABASE_URL
+              key: JWT_SECRET_KEY
+
+        # From Secrets
         - name: JWT_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -99,12 +99,3 @@ spec:
     name: postgres
   selector:
     app: postgres
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres-credentials
-  namespace: bbb-production
-type: Opaque
-stringData:
-  password: "CHANGEME-generate-strong-password"

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -83,12 +83,3 @@ spec:
     name: redis
   selector:
     app: redis
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: redis-credentials
-  namespace: bbb-production
-type: Opaque
-stringData:
-  password: "CHANGEME-generate-strong-password"

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -50,6 +50,8 @@ spec:
           exec:
             command:
             - redis-cli
+            - -a
+            - $(REDIS_PASSWORD)
             - ping
           initialDelaySeconds: 30
           periodSeconds: 10
@@ -57,6 +59,8 @@ spec:
           exec:
             command:
             - redis-cli
+            - -a
+            - $(REDIS_PASSWORD)
             - ping
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -28,11 +28,9 @@ spec:
         - containerPort: 6379
           name: redis
         command:
-        - redis-server
-        - --appendonly
-        - "yes"
-        - --requirepass
-        - "$(REDIS_PASSWORD)"
+        - /bin/sh
+        - -c
+        - exec redis-server --appendonly yes --requirepass "$REDIS_PASSWORD"
         env:
         - name: REDIS_PASSWORD
           valueFrom:
@@ -49,19 +47,17 @@ spec:
         livenessProbe:
           exec:
             command:
-            - redis-cli
-            - -a
-            - $(REDIS_PASSWORD)
-            - ping
+            - /bin/sh
+            - -c
+            - redis-cli -a "$REDIS_PASSWORD" ping
           initialDelaySeconds: 30
           periodSeconds: 10
         readinessProbe:
           exec:
             command:
-            - redis-cli
-            - -a
-            - $(REDIS_PASSWORD)
-            - ping
+            - /bin/sh
+            - -c
+            - redis-cli -a "$REDIS_PASSWORD" ping
           initialDelaySeconds: 5
           periodSeconds: 5
         volumeMounts:

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -11,9 +11,6 @@ metadata:
   namespace: bbb-production
 type: Opaque
 stringData:
-  # Database (replace with actual values)
-  DATABASE_URL: "postgresql://bbbuser:CHANGEME@postgres:5432/bbb_production"
-
   # JWT Secret
   JWT_SECRET_KEY: "CHANGEME-generate-with-openssl-rand-base64-32"
 

--- a/src/blank_business_builder/main.py
+++ b/src/blank_business_builder/main.py
@@ -90,14 +90,20 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Mount static files
-app.mount("/static", StaticFiles(directory="static"), name="static")
+PACKAGE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = PACKAGE_DIR.parents[1]
+STATIC_DIR = REPO_ROOT / "static"
+
+
+# Mount static files using an absolute path so the app starts reliably from the
+# Docker image working directory and local development shells.
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
 @app.get("/")
 async def root():
     """Serve the main admin dashboard SPA."""
-    return FileResponse("static/index.html")
+    return FileResponse(STATIC_DIR / "index.html")
 
 
 @app.on_event("startup")
@@ -118,23 +124,20 @@ async def stop_self_healing():
     if task:
         task.cancel()
 
-PACKAGE_DIR = Path(__file__).resolve().parent
-REPO_ROOT = PACKAGE_DIR.parents[2]
 LAB_PAGES = {
     "business-builder": PACKAGE_DIR / "business_builder_gui.html",
     "dashboard": PACKAGE_DIR / "dashboard.html",
     "quantum-features": PACKAGE_DIR / "quantum_features_dashboard.html",
-    "bbb-realtime": REPO_ROOT / "bbb_realtime_dashboard.html",
-    "bbb-unified-library": REPO_ROOT / "bbb_unified_library_dashboard.html",
-    "disaster-recovery": REPO_ROOT / "disaster_recovery_dashboard.html",
-    "quantum-analysis": REPO_ROOT / "quantum_analysis_dashboard.html",
-    "test-dashboard": REPO_ROOT / "test_dashboard.html",
-    "website-status": REPO_ROOT / "website_status_dashboard.html",
-    "zero-touch-businesses": REPO_ROOT / "zero_touch_businesses_dashboard.html",
+    "bbb-realtime": PACKAGE_DIR / "bbb_realtime_dashboard.html",
+    "bbb-unified-library": PACKAGE_DIR / "bbb_unified_library_dashboard.html",
+    "disaster-recovery": PACKAGE_DIR / "disaster_recovery_dashboard.html",
+    "quantum-analysis": PACKAGE_DIR / "quantum_analysis_dashboard.html",
+    "website-status": PACKAGE_DIR / "website_status_dashboard.html",
+    "zero-touch-businesses": PACKAGE_DIR / "zero_touch_businesses_dashboard.html",
 }
 LAB_ASSETS = {
-    "quantum_optimization_results.json": REPO_ROOT / "quantum_optimization_results.json",
-    "PHASE_2_COMPLETE.md": REPO_ROOT / "PHASE_2_COMPLETE.md",
+    "quantum_optimization_results.json": REPO_ROOT / "data" / "quantum_optimization_results.json",
+    "PHASE_2_COMPLETE.md": REPO_ROOT / "docs" / "architecture" / "PHASE_2_COMPLETE.md",
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Copy static, data, and lab documentation assets into the production Docker image.
- Resolve FastAPI static/lab paths from the repository root inside the container.
- Wire Kubernetes app pods to Postgres and Redis credentials consistently, including authenticated Redis startup and probes.
- Add a GitHub Actions `Kubernetes Auto Deploy` workflow that builds/pushes the BBB API image to GHCR, manages Kubernetes runtime secrets, deploys Postgres/Redis, runs migrations, rolls out the API image, and optionally applies ingress.
- Update Kubernetes deployment docs and remove stale placeholder Secret resources from Postgres/Redis manifests so workflow-managed credentials are not overwritten.

## Validation
- `git diff --check`
- `python3 -m py_compile src/blank_business_builder/main.py`
- Parsed `.github/workflows/kubernetes-auto-deploy.yml` with PyYAML and asserted the deploy job exists.
- Parsed all primary Kubernetes manifests with PyYAML and asserted `apiVersion`, `kind`, and `metadata` on each Kubernetes document.
- Verified all FastAPI-served static/lab asset paths exist in the repository.

## Notes
- Docker and kubectl are not installed in this cloud environment, so image build and server-side Kubernetes dry-run were not available here.
- Auto-deploy requires GitHub secrets documented in `k8s/README.md`, especially `KUBE_CONFIG_PRODUCTION`, `BBB_JWT_SECRET_KEY`, `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, and `ENCRYPTION_KEY`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9f133c3-e80f-4d90-a186-13d97ad633f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9f133c3-e80f-4d90-a186-13d97ad633f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

