### PR TITLE
Fix local development startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "PyJWT>=2.8.0",
     "passlib[bcrypt]>=1.7.4",
+    "email-validator>=2.3.0",
     "python-dotenv>=1.0.0",
 
     # Payment Processing

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
 bcrypt==3.2.2  # Required for passlib compatibility
 python-dotenv==1.0.0
+email-validator==2.3.0
 
 # Payment Processing
 stripe==9.6.0

--- a/src/blank_business_builder/database.py
+++ b/src/blank_business_builder/database.py
@@ -281,27 +281,6 @@ class Subscription(Base):
         return f"<Subscription(id={self.id}, user_id={self.user_id}, plan={self.plan_name}, status={self.status})>"
 
 
-class PaymentTransaction(Base):
-    """Payment transaction records"""
-    __tablename__ = 'payment_transactions'
-
-    id = Column(UUIDType(), primary_key=True, default=uuid.uuid4)
-    user_id = Column(UUIDType(), ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True)
-    stripe_payment_intent_id = Column(String(255), index=True)
-    amount = Column(Numeric(12, 2))
-    currency = Column(String(10))
-    status = Column(String(50))
-    description = Column(String(255), nullable=True)
-    transaction_metadata = Column(JSONType(), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-
-    # Relationships
-    user = relationship("User", back_populates="payment_transactions")
-
-    def __repr__(self):
-        return f"<PaymentTransaction(id={self.id}, user_id={self.user_id}, status={self.status})>"
-
-
 class MarketingCampaign(Base):
     """Marketing campaign records"""
     __tablename__ = 'marketing_campaigns'

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -25,9 +25,11 @@ def test_cors_restricted_by_default():
     # Check allow_origins in the middleware options
     # Note: If tests run after other tests that set CORS_ORIGINS, this might fail
     # unless we ensure a fresh state.
-    assert isinstance(cors_middleware.options["allow_origins"], list)
+    middleware_options = getattr(cors_middleware, "options", cors_middleware.kwargs)
+
+    assert isinstance(middleware_options["allow_origins"], list)
     if not os.getenv("CORS_ORIGINS"):
-        assert cors_middleware.options["allow_origins"] == []
+        assert middleware_options["allow_origins"] == []
 
 def test_cors_parsing_logic():
     """Test the logic for parsing CORS_ORIGINS string."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the duplicate `PaymentTransaction` ORM declaration that prevented importing the database module.
- Add the missing `email-validator` dependency required by Pydantic `EmailStr` models.
- Update the CORS middleware test to support the current Starlette/FastAPI middleware metadata shape.

### Validation
- Local Python virtual environment installed with `pip install -e ".[dev]"`.
- Local SQLite database initialized from the app models.
- FastAPI app started locally with Uvicorn on port 8000.
- Smoke checked `/health`, `/`, and `/labs` endpoints successfully.
- Focused pytest smoke suite passes: `tests/test_middleware_main.py tests/test_cors_security.py tests/test_gui_server.py`.
- Browser walkthrough recorded: [bbb_dev_environment_smoke_walkthrough.mp4](https://cursor.com/agents/bc-7ccf659a-4f11-4fd2-944c-d295dbb2e838/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbbb_dev_environment_smoke_walkthrough.mp4)

### Notes
- Docker is not installed in the Cursor Cloud VM, so validation uses the local Python development path with an ignored `.env` and SQLite.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ccf659a-4f11-4fd2-944c-d295dbb2e838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ccf659a-4f11-4fd2-944c-d295dbb2e838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

