### PR TITLE
Use BBB persona in Bland calls and add CSV batch runner

### DIFF
--- a/scripts/tools/run_bbb_persona_batch.py
+++ b/scripts/tools/run_bbb_persona_batch.py
@@ -1,0 +1,239 @@
+"""
+Run Bland batch calls using the BBB persona and a CSV lead sheet.
+
+Usage:
+  python3 scripts/tools/run_bbb_persona_batch.py --csv okc_edmond_bland_batch.csv
+
+Required environment variables:
+  BLAND_API_KEY
+  BBB_PERSONA_ID
+
+Optional environment variables:
+  BLAND_FROM_NUMBER
+  BLAND_WEBHOOK_URL
+  BLAND_BATCH_SIZE (default 50)
+  BLAND_MAX_DURATION_MINUTES (default 8)
+  BLAND_BATCH_LABEL_PREFIX (default "BBB Persona Batch")
+  BLAND_RECORD_CALLS (default true)
+  BLAND_WAIT_FOR_GREETING (default true)
+  BLAND_DEFAULT_LANGUAGE (default en-US)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+from typing import Any, Dict, Iterable, List
+
+import requests
+
+
+BLAND_BATCH_ENDPOINT = "https://api.bland.ai/v1/batches"
+
+
+def _to_bool(value: str, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def _required_env(name: str) -> str:
+    value = _env(name)
+    if not value:
+        raise ValueError(f"Missing required environment variable: {name}")
+    return value
+
+
+def read_leads(csv_path: str) -> List[Dict[str, str]]:
+    leads: List[Dict[str, str]] = []
+    with open(csv_path, "r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            phone = (row.get("phone_number") or row.get("phone") or "").strip()
+            if not phone:
+                continue
+            leads.append({k: (v or "").strip() for k, v in row.items()})
+    return leads
+
+
+def _request_data(lead: Dict[str, str]) -> Dict[str, Any]:
+    full_name = " ".join(
+        token for token in [lead.get("first_name", ""), lead.get("last_name", "")] if token
+    ).strip()
+    return {
+        "first_name": lead.get("first_name", ""),
+        "last_name": lead.get("last_name", ""),
+        "homeowner_name": full_name,
+        "property_address": lead.get("property_address", ""),
+        "city": lead.get("city", ""),
+        "state": lead.get("state", ""),
+        "zip_code": lead.get("zip_code", ""),
+        "hail_date": lead.get("hail_date", ""),
+        "storm_date": lead.get("hail_date", ""),
+        "hail_size": lead.get("hail_size", ""),
+        "storm_type": lead.get("storm_type", ""),
+        "damage_probability": lead.get("damage_probability", ""),
+        "structures_hit": lead.get("structures_hit", ""),
+        "image_findings": lead.get("image_findings", ""),
+        "lead_priority": lead.get("lead_priority", ""),
+        "callback_number": lead.get("phone_number", ""),
+    }
+
+
+def _analysis_schema() -> Dict[str, Any]:
+    # Keep schema simple and strict enough for post-call automation.
+    return {
+        "type": "object",
+        "properties": {
+            "lead_priority": {"type": "string"},
+            "homeowner_name": {"type": "string"},
+            "property_address": {"type": "string"},
+            "callback_number": {"type": "string"},
+            "inspection_booked": {"type": "boolean"},
+            "preferred_inspection_time": {"type": "string"},
+            "call_outcome": {"type": "string"},
+            "notes": {"type": "string"},
+        },
+        "required": [
+            "lead_priority",
+            "inspection_booked",
+            "call_outcome",
+            "notes",
+        ],
+    }
+
+
+def _call_payload(
+    lead: Dict[str, str],
+    *,
+    persona_id: str,
+    webhook: str,
+    from_number: str,
+    language: str,
+    max_duration: int,
+    record: bool,
+    wait_for_greeting: bool,
+) -> Dict[str, Any]:
+    phone = lead.get("phone_number") or lead.get("phone") or ""
+    payload = {
+        "phone_number": phone,
+        "persona_id": persona_id,
+        "webhook": webhook,
+        "request_data": _request_data(lead),
+        "analysis_schema": _analysis_schema(),
+        "max_duration": max_duration,
+        "record": record,
+        "wait_for_greeting": wait_for_greeting,
+        "language": language,
+        "metadata": {
+            "lead_source": lead.get("source", "csv_batch"),
+            "campaign": lead.get("campaign", ""),
+            "city": lead.get("city", ""),
+            "state": lead.get("state", ""),
+            "property_address": lead.get("property_address", ""),
+        },
+    }
+    if from_number:
+        payload["from"] = from_number
+    return payload
+
+
+def chunked(items: List[Dict[str, str]], size: int) -> Iterable[List[Dict[str, str]]]:
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def send_batch(
+    *,
+    bland_api_key: str,
+    call_data: List[Dict[str, Any]],
+    label: str,
+) -> Dict[str, Any]:
+    response = requests.post(
+        BLAND_BATCH_ENDPOINT,
+        headers={
+            "Authorization": bland_api_key,
+            "Content-Type": "application/json",
+        },
+        json={"label": label, "call_data": call_data},
+        timeout=45,
+    )
+    response.raise_for_status()
+    return response.json() if response.content else {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Bland batch calls with BBB persona.")
+    parser.add_argument("--csv", required=True, help="Path to CSV lead sheet")
+    parser.add_argument("--sleep-seconds", type=float, default=2.0, help="Pause between batches")
+    args = parser.parse_args()
+
+    try:
+        bland_api_key = _required_env("BLAND_API_KEY")
+        persona_id = _required_env("BBB_PERSONA_ID")
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    from_number = _env("BLAND_FROM_NUMBER")
+    webhook = _env("BLAND_WEBHOOK_URL")
+    if not webhook:
+        print("Missing BLAND_WEBHOOK_URL", file=sys.stderr)
+        return 2
+
+    batch_size = int(_env("BLAND_BATCH_SIZE", "50"))
+    max_duration = int(_env("BLAND_MAX_DURATION_MINUTES", "8"))
+    label_prefix = _env("BLAND_BATCH_LABEL_PREFIX", "BBB Persona Batch")
+    language = _env("BLAND_DEFAULT_LANGUAGE", "en-US")
+    record_calls = _to_bool(os.getenv("BLAND_RECORD_CALLS"), True)
+    wait_for_greeting = _to_bool(os.getenv("BLAND_WAIT_FOR_GREETING"), True)
+
+    leads = read_leads(args.csv)
+    if not leads:
+        print(f"No callable leads found in {args.csv}", file=sys.stderr)
+        return 1
+
+    print(f"Loaded {len(leads)} leads from {args.csv}")
+    total_batches = (len(leads) + batch_size - 1) // batch_size
+
+    for idx, leads_batch in enumerate(chunked(leads, batch_size), start=1):
+        call_data = [
+            _call_payload(
+                lead,
+                persona_id=persona_id,
+                webhook=webhook,
+                from_number=from_number,
+                language=language,
+                max_duration=max_duration,
+                record=record_calls,
+                wait_for_greeting=wait_for_greeting,
+            )
+            for lead in leads_batch
+        ]
+        label = f"{label_prefix} {time.strftime('%Y-%m-%d %H:%M:%S')} #{idx}/{total_batches}"
+        print(f"\nSending batch {idx}/{total_batches} ({len(call_data)} calls)")
+
+        try:
+            result = send_batch(bland_api_key=bland_api_key, call_data=call_data, label=label)
+            print(json.dumps(result, indent=2))
+        except Exception as exc:
+            print(f"Batch {idx} failed: {exc}", file=sys.stderr)
+            return 1
+
+        if idx < total_batches:
+            time.sleep(max(0, args.sleep_seconds))
+
+    print("\nAll batches submitted.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/blank_business_builder/agents/voice_agent.py
+++ b/src/blank_business_builder/agents/voice_agent.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
-
+from urllib.parse import urljoin
 from sqlalchemy.orm import Session
 
+from ..config import settings
 from ..database import CallSession, LeadRecord, OutreachAttempt, ProviderEvent
 from ..echo_master_brain import EchoMasterBrain
 from ..integrations import IntegrationFactory
@@ -22,6 +23,49 @@ class VoiceAgent:
         self.bland = IntegrationFactory.get_bland_service()
         self.slack = IntegrationFactory.get_slack_service()
         self.brain = EchoMasterBrain()
+        self.default_persona_id = settings.BBB_PERSONA_ID
+        self.default_from_number = settings.BLAND_FROM_NUMBER
+        self.default_language = settings.BLAND_DEFAULT_LANGUAGE
+        self.default_max_duration = settings.BLAND_MAX_DURATION_MINUTES
+        self.default_record_calls = settings.BLAND_RECORD_CALLS
+        self.default_wait_for_greeting = settings.BLAND_WAIT_FOR_GREETING
+
+    def _absolute_webhook(self, webhook_url: Optional[str]) -> str:
+        """Resolve relative webhook paths against ECHO_BASE_URL when possible."""
+        webhook = (webhook_url or "").strip()
+        if not webhook:
+            return ""
+        if webhook.startswith("http://") or webhook.startswith("https://"):
+            return webhook
+        base = settings.ECHO_BASE_URL.strip()
+        if not base:
+            return webhook
+        return urljoin(base.rstrip("/") + "/", webhook.lstrip("/"))
+
+    @staticmethod
+    def build_request_data_from_lead(lead: LeadRecord) -> Dict[str, Any]:
+        """Map a lead record into Bland request_data fields used by BBB persona."""
+        first_name = (lead.first_name or "").strip()
+        last_name = (lead.last_name or "").strip()
+        return {
+            "first_name": first_name,
+            "last_name": last_name,
+            "homeowner_name": (lead.full_name or f"{first_name} {last_name}".strip()).strip(),
+            "property_address": "",
+            "business_name": lead.company or "",
+            "company": lead.company or "",
+            "city": "",
+            "state": "",
+            "zip_code": "",
+            "storm_date": "",
+            "hail_size": "",
+            "storm_type": "",
+            "damage_probability": "",
+            "structures_hit": "",
+            "image_findings": "",
+            "lead_priority": str(lead.outreach_priority or ""),
+            "callback_number": lead.phone or "",
+        }
 
     def create_outreach_call(
         self,
@@ -32,6 +76,14 @@ class VoiceAgent:
         department: str,
         script: str,
         task: str,
+        persona_id: Optional[str] = None,
+        from_number: Optional[str] = None,
+        request_data: Optional[Dict[str, Any]] = None,
+        max_duration: Optional[int] = None,
+        record: Optional[bool] = None,
+        wait_for_greeting: Optional[bool] = None,
+        language: Optional[str] = None,
+        analysis_schema: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Create Bland call + persist outreach/call session records."""
         outreach = OutreachAttempt(
@@ -45,15 +97,26 @@ class VoiceAgent:
         db.add(outreach)
         db.flush()
 
+        resolved_webhook = self._absolute_webhook(webhook_url)
         call_response = self.bland.create_call(
             phone_number=lead.phone or "",
             task=task,
-            webhook=webhook_url,
+            webhook=resolved_webhook,
             metadata={
                 "lead_id": str(lead.id),
                 "outreach_attempt_id": str(outreach.id),
                 "department": department,
             },
+            persona_id=persona_id or self.default_persona_id or None,
+            from_number=from_number or self.default_from_number or None,
+            request_data=request_data or self.build_request_data_from_lead(lead),
+            max_duration=max_duration if max_duration is not None else self.default_max_duration,
+            record=self.default_record_calls if record is None else record,
+            wait_for_greeting=self.default_wait_for_greeting
+            if wait_for_greeting is None
+            else wait_for_greeting,
+            language=language or self.default_language,
+            analysis_schema=analysis_schema,
         )
         provider_call_id = str(call_response.get("call_id") or call_response.get("id") or outreach.id)
         call = CallSession(

--- a/src/blank_business_builder/config.py
+++ b/src/blank_business_builder/config.py
@@ -71,6 +71,12 @@ class Config:
     BLAND_API_KEY = os.getenv("BLAND_API_KEY", "")
     BLAND_WEBHOOK_SECRET = os.getenv("BLAND_WEBHOOK_SECRET", "")
     BLAND_BASE_URL = os.getenv("BLAND_BASE_URL", "https://api.bland.ai")
+    BBB_PERSONA_ID = os.getenv("BBB_PERSONA_ID", "")
+    BLAND_FROM_NUMBER = os.getenv("BLAND_FROM_NUMBER", "")
+    BLAND_DEFAULT_LANGUAGE = os.getenv("BLAND_DEFAULT_LANGUAGE", "en-US")
+    BLAND_MAX_DURATION_MINUTES = int(os.getenv("BLAND_MAX_DURATION_MINUTES", "8"))
+    BLAND_WAIT_FOR_GREETING = os.getenv("BLAND_WAIT_FOR_GREETING", "true").lower() == "true"
+    BLAND_RECORD_CALLS = os.getenv("BLAND_RECORD_CALLS", "true").lower() == "true"
 
     APOLLO_API_KEY = os.getenv("APOLLO_API_KEY", "")
     APOLLO_BASE_URL = os.getenv("APOLLO_BASE_URL", "https://api.apollo.io")

--- a/src/blank_business_builder/integrations/bland.py
+++ b/src/blank_business_builder/integrations/bland.py
@@ -56,6 +56,13 @@ class BlandService:
         metadata: Optional[Dict[str, Any]] = None,
         pathway_id: Optional[str] = None,
         from_number: Optional[str] = None,
+        persona_id: Optional[str] = None,
+        request_data: Optional[Dict[str, Any]] = None,
+        max_duration: Optional[int] = None,
+        record: Optional[bool] = None,
+        wait_for_greeting: Optional[bool] = None,
+        language: Optional[str] = None,
+        analysis_schema: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Create an outbound Bland call with per-call webhook callback."""
         body: Dict[str, Any] = {
@@ -69,6 +76,20 @@ class BlandService:
             body["pathway_id"] = pathway_id
         if from_number:
             body["from"] = from_number
+        if persona_id:
+            body["persona_id"] = persona_id
+        if request_data:
+            body["request_data"] = request_data
+        if max_duration is not None:
+            body["max_duration"] = max_duration
+        if record is not None:
+            body["record"] = record
+        if wait_for_greeting is not None:
+            body["wait_for_greeting"] = wait_for_greeting
+        if language:
+            body["language"] = language
+        if analysis_schema:
+            body["analysis_schema"] = analysis_schema
         return self._request("POST", "/v1/calls", body)
 
     def get_call(self, call_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extend `BlandService.create_call()` to support persona-driven outbound options used by BBB:
  - `persona_id`
  - `request_data`
  - `max_duration`
  - `record`
  - `wait_for_greeting`
  - `language`
  - `analysis_schema`
- update `VoiceAgent` to default to BBB persona configuration from environment:
  - `BBB_PERSONA_ID`
  - `BLAND_FROM_NUMBER`
  - `BLAND_DEFAULT_LANGUAGE`
  - `BLAND_MAX_DURATION_MINUTES`
  - `BLAND_RECORD_CALLS`
  - `BLAND_WAIT_FOR_GREETING`
- add request-data mapping utility in `VoiceAgent` for BBB persona variables (e.g. `first_name`, `property_address`, `hail_size`, `structures_hit`, `image_findings`, etc.)
- add relative webhook resolution support against `ECHO_BASE_URL`
- add production utility script:
  - `scripts/tools/run_bbb_persona_batch.py`
  - reads lead CSV, chunks to Bland limits, submits `/v1/batches` with `persona_id=BBB_PERSONA_ID`

## Configuration added
- `BBB_PERSONA_ID`
- `BLAND_FROM_NUMBER`
- `BLAND_DEFAULT_LANGUAGE`
- `BLAND_MAX_DURATION_MINUTES`
- `BLAND_WAIT_FOR_GREETING`
- `BLAND_RECORD_CALLS`

## Verification
Executed:
- `python3 -m pytest tests/test_bland_integration.py tests/test_outreach_flow.py`

Result:
- **3 passed**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-176af4a9-10f9-4dca-9490-a37742744d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-176af4a9-10f9-4dca-9490-a37742744d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

