### PR TITLE
Add Echo Prime Kubernetes service

### DIFF
--- a/.github/workflows/kubernetes-auto-deploy.yml
+++ b/.github/workflows/kubernetes-auto-deploy.yml
@@ -280,6 +280,17 @@ jobs:
             -n "${K8S_NAMESPACE}" \
             --timeout=10m
 
+      - name: Deploy Echo Prime
+        run: |
+          set -euo pipefail
+          kubectl apply -f k8s/echo-prime.yaml
+          kubectl set image deployment/echo-prime \
+            echo-prime="${IMAGE_NAME}:${GITHUB_SHA}" \
+            -n "${K8S_NAMESPACE}"
+          kubectl rollout status deployment/echo-prime \
+            -n "${K8S_NAMESPACE}" \
+            --timeout=10m
+
       - name: Apply ingress
         if: ${{ github.event_name == 'push' || inputs.deploy_ingress }}
         run: |

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -84,6 +84,7 @@ Use the same image tag here that you deploy in `k8s/deployment.yaml`.
 ### 6. Deploy Application
 
 ```bash
+kubectl apply -f k8s/echo-prime.yaml
 kubectl apply -f k8s/deployment.yaml
 ```
 
@@ -123,6 +124,7 @@ kubectl get ingress -n bbb-production
 
 # View logs
 kubectl logs -f deployment/bbb-api -n bbb-production
+kubectl logs -f deployment/echo-prime -n bbb-production
 
 # Check HPA status
 kubectl get hpa -n bbb-production

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -16,6 +16,7 @@ data:
   # API settings
   API_HOST: "0.0.0.0"
   API_PORT: "8000"
+  ECHO_BASE_URL: "http://echo-prime-service:8000"
 
   # CORS settings
   CORS_ORIGINS: "*"
@@ -29,3 +30,5 @@ data:
   ENABLE_AUTH0: "false"
   ENABLE_MONITORING: "true"
   ENABLE_WEBSOCKETS: "true"
+  ECH0_LLM_PROVIDER: "huggingface"
+  ECH0_LLM_ENDPOINT: "https://workofarttattoo-echo-prime-agi.hf.space/api/predict"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -63,6 +63,8 @@ spec:
             secretKeyRef:
               name: bbb-secrets
               key: JWT_SECRET_KEY
+        - name: ECHO_BASE_URL
+          value: "http://echo-prime-service:8001"
 
         # From Secrets
         - name: JWT_SECRET_KEY

--- a/k8s/echo-prime.yaml
+++ b/k8s/echo-prime.yaml
@@ -1,0 +1,135 @@
+# Copyright (c) 2025 Joshua Hendricks Cole (DBA: Corporation of Light). All Rights Reserved. PATENT PENDING.
+#
+# Echo Prime private reasoning service for BBB.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-prime
+  namespace: bbb-production
+  labels:
+    app: echo-prime
+    component: reasoning
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: echo-prime
+  template:
+    metadata:
+      labels:
+        app: echo-prime
+        component: reasoning
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8001"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+      - name: echo-prime
+        image: bbb/api:latest
+        imagePullPolicy: Always
+        command:
+        - uvicorn
+        - blank_business_builder.echo_prime_api:app
+        - --host
+        - "0.0.0.0"
+        - --port
+        - "8001"
+        - --workers
+        - "2"
+        ports:
+        - containerPort: 8001
+          name: http
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: bbb-config
+        env:
+        - name: ECHO_PRIME_NAME
+          value: "echo_prime"
+        - name: ECHO_PRIME_MODE
+          value: "cluster"
+        - name: ECH0_LLM_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: bbb-secrets
+              key: ECH0_LLM_API_KEY
+              optional: true
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "1000m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+      terminationGracePeriodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-prime-service
+  namespace: bbb-production
+  labels:
+    app: echo-prime
+    component: reasoning
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8001
+    targetPort: 8001
+    protocol: TCP
+    name: http
+  selector:
+    app: echo-prime
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: echo-prime-hpa
+  namespace: bbb-production
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: echo-prime
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/src/blank_business_builder/echo_prime_api.py
+++ b/src/blank_business_builder/echo_prime_api.py
@@ -1,0 +1,73 @@
+"""
+Private Echo Prime API for in-cluster BBB reasoning.
+
+This service exposes the internal decision routes used by BBB's
+EchoMasterBrain client. It keeps deterministic fallback behavior available even
+when an external LLM endpoint is unavailable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from .echo_master_brain import EchoMasterBrain
+from .ech0_service import ECH0Service
+
+
+app = FastAPI(
+    title="Echo Prime API",
+    description="Private reasoning service for BBB autonomous operations",
+    version="1.0.0",
+)
+
+brain = EchoMasterBrain(base_url="")
+ech0_service = ECH0Service()
+
+
+class OutreachDecisionRequest(BaseModel):
+    lead_event: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PostCallDecisionRequest(BaseModel):
+    call_event: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+@app.get("/health")
+async def health_check() -> Dict[str, str]:
+    """Kubernetes health endpoint."""
+    return {
+        "service": "echo-prime",
+        "status": "healthy",
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+
+
+@app.post("/internal/echo/outreach-decision")
+@app.post("/v1/outreach/decision")
+@app.post("/outreach/decision")
+async def decide_outreach(request: OutreachDecisionRequest) -> Dict[str, Any]:
+    """Choose outbound department, priority, script, and next action."""
+    return brain.decide_outreach(request.lead_event)
+
+
+@app.post("/internal/echo/post-call-decision")
+@app.post("/v1/outreach/post-call")
+@app.post("/outreach/post-call")
+async def decide_post_call_action(request: PostCallDecisionRequest) -> Dict[str, Any]:
+    """Choose follow-up action after a call provider posts final results."""
+    return brain.decide_post_call_action(request.call_event)
+
+
+@app.post("/v1/chat")
+async def chat(request: ChatRequest) -> Dict[str, str]:
+    """Small private chat endpoint for operational checks and future tools."""
+    response = await ech0_service.chat(request.message)
+    return {"response": response}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a private `echo-prime` FastAPI service exposing the internal decision routes used by BBB.
- Add Kubernetes Deployment, Service, and HPA for Echo Prime on port 8001.
- Wire BBB's `ECHO_BASE_URL` to the in-cluster Echo Prime service.
- Update the Kubernetes auto-deploy workflow to roll out Echo Prime with the same image as BBB.
- Document Echo Prime deployment and verification commands.

## Validation
- `python3 -m py_compile src/blank_business_builder/echo_prime_api.py src/blank_business_builder/echo_master_brain.py`
- FastAPI `TestClient` smoke test for `/health`, `/internal/echo/outreach-decision`, and `/internal/echo/post-call-decision`.
- Parsed `.github/workflows/kubernetes-auto-deploy.yml` with PyYAML and asserted the deploy job exists.
- Parsed all primary Kubernetes manifests, including `k8s/echo-prime.yaml`, with PyYAML and asserted `apiVersion`, `kind`, and `metadata` on each Kubernetes document.
- `git diff --check`

## Notes
- Docker and kubectl are not installed in this cloud environment, so image build and server-side Kubernetes dry-run were not available here.
- Full `pip install -r requirements.txt` is currently blocked by an existing dependency conflict: `safety==2.3.5` requires `packaging<22`, while `black==24.1.1` requires `packaging>=22`. Minimal runtime packages were installed for the Echo Prime smoke test.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9f133c3-e80f-4d90-a186-13d97ad633f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9f133c3-e80f-4d90-a186-13d97ad633f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

