### PR TITLE
Add BBB lead generation and marketing wizard screens

### DIFF
--- a/src/blank_business_builder/business_builder_gui.html
+++ b/src/blank_business_builder/business_builder_gui.html
@@ -1182,10 +1182,16 @@
                         <p style="margin-top:0.75rem;color:var(--text-dim);">${tools.bland.outreach_goal}</p>
                     </div>
                     <div class="setup-card">
-                        <h3>Website + Delivery</h3>
+                        <h3>Website</h3>
                         <div class="status-chip">${tools.website.status}</div>
+                        <p style="margin-top:0.75rem;color:var(--text-dim);">${tools.website.pages_url || 'GitHub Pages URL pending'}</p>
+                    </div>
+                    <div class="setup-card">
+                        <h3>BBB + Echo Delivery</h3>
+                        <div class="status-chip">${tools.marketing.status}</div>
                         <div class="status-chip">${tools.delivery.status}</div>
-                        <p style="margin-top:0.75rem;color:var(--text-dim);">${tools.delivery.delivery_path}</p>
+                        <p style="margin-top:0.75rem;color:var(--text-dim);">${tools.marketing.handoff}</p>
+                        <p style="margin-top:0.5rem;color:var(--text-dim);">${tools.delivery.delivery_path}</p>
                     </div>
                 </div>
                 <ol class="pipeline-list">

--- a/src/blank_business_builder/business_builder_gui.html
+++ b/src/blank_business_builder/business_builder_gui.html
@@ -1189,9 +1189,8 @@
                     <div class="setup-card">
                         <h3>BBB + Echo Delivery</h3>
                         <div class="status-chip">${tools.marketing.status}</div>
-                        <div class="status-chip">${tools.delivery.status}</div>
                         <p style="margin-top:0.75rem;color:var(--text-dim);">${tools.marketing.handoff}</p>
-                        <p style="margin-top:0.5rem;color:var(--text-dim);">${tools.delivery.delivery_path}</p>
+                        <p style="margin-top:0.5rem;color:var(--text-dim);">Delivery: ${tools.delivery.status} - ${tools.delivery.delivery_path}</p>
                     </div>
                 </div>
                 <ol class="pipeline-list">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Pointed the Uvicorn-served Stitch-style onboarding wizard at same-origin `/api/v1` endpoints.
- Completed the wizard handoff so license/admin unlock advances into post-owner setup instead of stopping at the dashboard.
- Added separate Step 7 Lead Generation and Step 8 Marketing + Fulfillment GUI screens.
- Added a Headhunter/Apollo, Bland, GitHub Pages, Google Workspace/Drive, BBB/Echo acquisition setup endpoint that stores only non-secret setup state while loading API keys into the running process env.
- Added dashboard Client Acquisition Pipeline cards and repeat-for-each-new-business pipeline status.
- Corrected Owner Tier dashboard math so `Your Share` matches `Revenue Today` for 100% equity.
- Polished dropdown contrast, EIN checkbox alignment, and acquisition dashboard card statuses.
- Added API coverage for onboarding through active dashboard and acquisition launch.

### Testing
- `./.venv/bin/python -m pytest tests/test_gui_server.py` passed: 9 tests.
- Manual GUI walkthrough served via `uvicorn src.blank_business_builder.gui_server:app --host 0.0.0.0 --port 8000` completed Owner Tier, Lead Generation, Marketing + Fulfillment, and verified the Client Acquisition Pipeline dashboard.

### Walkthrough
[bbb_split_lead_marketing_verified.mp4](https://cursor.com/agents/bc-3373d0bb-661e-45f1-b1de-a383a0261c65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbbb_split_lead_marketing_verified.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3373d0bb-661e-45f1-b1de-a383a0261c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3373d0bb-661e-45f1-b1de-a383a0261c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

