### PR TITLE
Add Azure deployment and ElevenLabs outreach assets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ ECH0_LLM_API_KEY=
 ECH0_LLM_TIMEOUT_SECONDS=180
 ECHO_BASE_URL=
 ECHO_PRIME_BASE_URL=
+APP_MODULE=blank_business_builder.main:app
+PORT=8000
+WEB_CONCURRENCY=4
 
 # Twilio (SMS & Voice)
 TWILIO_ACCOUNT_SID=your_account_sid_here

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,26 @@ TWILIO_FROM_NUMBER=+15555555555
 
 # ElevenLabs (AI Voice)
 ELEVENLABS_API_KEY=your_elevenlabs_key_here
+ELEVENLABS_BASE_URL=https://api.elevenlabs.io
+ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+ELEVENLABS_MODEL_ID=eleven_multilingual_v2
+ELEVENLABS_OUTPUT_FORMAT=mp3_44100_128
+ELEVENLABS_OUTREACH_AUDIO_DIR=data/outreach_audio
+
+# Apollo / B2B lead discovery
+APOLLO_API_KEY=your_apollo_key_here
+APOLLO_BASE_URL=https://api.apollo.io
+
+# Voice outreach orchestration
+BLAND_API_KEY=
+BLAND_WEBHOOK_SECRET=
+BLAND_BASE_URL=https://api.bland.ai
+BBB_PERSONA_ID=
+BLAND_FROM_NUMBER=
+BLAND_DEFAULT_LANGUAGE=en-US
+BLAND_MAX_DURATION_MINUTES=8
+BLAND_WAIT_FOR_GREETING=true
+BLAND_RECORD_CALLS=true
 
 # SendGrid (Email)
 SENDGRID_API_KEY=your_sendgrid_key_here

--- a/.env.production.example
+++ b/.env.production.example
@@ -37,6 +37,12 @@ ECH0_LLM_API_KEY=
 ECH0_LLM_TIMEOUT_SECONDS=180
 ECHO_BASE_URL=http://echo-prime-service:8001
 ECHO_PRIME_BASE_URL=http://echo-prime-service:8001
+# Azure Container Apps sets these per service:
+# BBB API: APP_MODULE=blank_business_builder.main:app, PORT=8000
+# Echo Prime: APP_MODULE=blank_business_builder.echo_prime_api:app, PORT=8001
+APP_MODULE=blank_business_builder.main:app
+PORT=8000
+WEB_CONCURRENCY=4
 
 # ============================================================
 # COMMUNICATIONS (optional but recommended)

--- a/.github/workflows/azure-container-app.yml
+++ b/.github/workflows/azure-container-app.yml
@@ -11,6 +11,7 @@ permissions:
 env:
   AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   AZURE_CONTAINER_APP_NAME: ${{ vars.AZURE_CONTAINER_APP_NAME }}
+  AZURE_ECHO_PRIME_APP_NAME: ${{ vars.AZURE_ECHO_PRIME_APP_NAME || 'echo-prime' }}
   AZURE_CONTAINER_APP_ENVIRONMENT: ${{ vars.AZURE_CONTAINER_APP_ENVIRONMENT }}
   AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
   AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'eastus' }}
@@ -41,7 +42,65 @@ jobs:
             --image "$IMAGE_NAME:latest" \
             .
 
-      - name: Create or update Container App
+      - name: Create or update Echo Prime Container App
+        env:
+          IMAGE: ${{ vars.AZURE_CONTAINER_REGISTRY }}.azurecr.io/better-business-builder:${{ github.sha }}
+          ECH0_LLM_PROVIDER: ${{ vars.ECH0_LLM_PROVIDER || 'ollama' }}
+          ECH0_LLM_ENDPOINT: ${{ vars.ECH0_LLM_ENDPOINT }}
+          ECH0_LLM_API_KEY: ${{ secrets.ECH0_LLM_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          echo_env=(
+            ENVIRONMENT=production
+            APP_MODULE=blank_business_builder.echo_prime_api:app
+            PORT=8001
+            WEB_CONCURRENCY=2
+            ECHO_BASE_URL=
+            ECHO_PRIME_BASE_URL=
+            ECH0_LLM_PROVIDER="$ECH0_LLM_PROVIDER"
+            ECH0_LLM_ENDPOINT="$ECH0_LLM_ENDPOINT"
+          )
+
+          if [ -n "${ECH0_LLM_API_KEY:-}" ]; then
+            echo_env+=(ECH0_LLM_API_KEY=secretref:ech0-llm-api-key)
+          fi
+
+          if az containerapp show \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_ECHO_PRIME_APP_NAME" >/dev/null 2>&1; then
+            if [ -n "${ECH0_LLM_API_KEY:-}" ]; then
+              az containerapp secret set \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --name "$AZURE_ECHO_PRIME_APP_NAME" \
+                --secrets ech0-llm-api-key="$ECH0_LLM_API_KEY"
+            fi
+
+            az containerapp update \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_ECHO_PRIME_APP_NAME" \
+              --image "$IMAGE" \
+              --set-env-vars "${echo_env[@]}"
+          else
+            create_args=(
+              --resource-group "$AZURE_RESOURCE_GROUP"
+              --name "$AZURE_ECHO_PRIME_APP_NAME"
+              --environment "$AZURE_CONTAINER_APP_ENVIRONMENT"
+              --location "$AZURE_LOCATION"
+              --image "$IMAGE"
+              --target-port 8001
+              --ingress internal
+              --min-replicas 1
+              --max-replicas 3
+              --env-vars "${echo_env[@]}"
+            )
+            if [ -n "${ECH0_LLM_API_KEY:-}" ]; then
+              create_args+=(--secrets ech0-llm-api-key="$ECH0_LLM_API_KEY")
+            fi
+            az containerapp create "${create_args[@]}"
+          fi
+
+      - name: Create or update BBB Container App
         env:
           IMAGE: ${{ vars.AZURE_CONTAINER_REGISTRY }}.azurecr.io/better-business-builder:${{ github.sha }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
@@ -49,16 +108,24 @@ jobs:
           REDIS_URL: ${{ secrets.REDIS_URL }}
           APOLLO_API_KEY: ${{ secrets.APOLLO_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
-          ECHO_BASE_URL: ${{ vars.ECHO_BASE_URL }}
           CORS_ORIGINS: ${{ vars.CORS_ORIGINS }}
         run: |
           set -euo pipefail
 
+          echo_fqdn=$(az containerapp show \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_ECHO_PRIME_APP_NAME" \
+            --query properties.configuration.ingress.fqdn \
+            --output tsv)
+          echo_prime_url="https://${echo_fqdn}"
+
           common_env=(
             ENVIRONMENT=production
+            APP_MODULE=blank_business_builder.main:app
             PORT=8000
-            ECHO_BASE_URL="$ECHO_BASE_URL"
-            ECHO_PRIME_BASE_URL="$ECHO_BASE_URL"
+            WEB_CONCURRENCY=4
+            ECHO_BASE_URL="$echo_prime_url"
+            ECHO_PRIME_BASE_URL="$echo_prime_url"
             CORS_ORIGINS="$CORS_ORIGINS"
             DATABASE_URL=secretref:database-url
             REDIS_URL=secretref:redis-url

--- a/.github/workflows/azure-container-app.yml
+++ b/.github/workflows/azure-container-app.yml
@@ -1,0 +1,115 @@
+name: Deploy Azure Container App
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+  AZURE_CONTAINER_APP_NAME: ${{ vars.AZURE_CONTAINER_APP_NAME }}
+  AZURE_CONTAINER_APP_ENVIRONMENT: ${{ vars.AZURE_CONTAINER_APP_ENVIRONMENT }}
+  AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+  AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'eastus' }}
+  IMAGE_NAME: better-business-builder
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Install Container Apps extension
+        run: az extension add --name containerapp --upgrade
+
+      - name: Build image in Azure Container Registry
+        run: |
+          az acr build \
+            --registry "$AZURE_CONTAINER_REGISTRY" \
+            --image "$IMAGE_NAME:${{ github.sha }}" \
+            --image "$IMAGE_NAME:latest" \
+            .
+
+      - name: Create or update Container App
+        env:
+          IMAGE: ${{ vars.AZURE_CONTAINER_REGISTRY }}.azurecr.io/better-business-builder:${{ github.sha }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          APOLLO_API_KEY: ${{ secrets.APOLLO_API_KEY }}
+          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          ECHO_BASE_URL: ${{ vars.ECHO_BASE_URL }}
+          CORS_ORIGINS: ${{ vars.CORS_ORIGINS }}
+        run: |
+          set -euo pipefail
+
+          common_env=(
+            ENVIRONMENT=production
+            PORT=8000
+            ECHO_BASE_URL="$ECHO_BASE_URL"
+            ECHO_PRIME_BASE_URL="$ECHO_BASE_URL"
+            CORS_ORIGINS="$CORS_ORIGINS"
+            DATABASE_URL=secretref:database-url
+            REDIS_URL=secretref:redis-url
+            SECRET_KEY=secretref:secret-key
+            APOLLO_API_KEY=secretref:apollo-api-key
+            ELEVENLABS_API_KEY=secretref:elevenlabs-api-key
+          )
+
+          if az containerapp show \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_CONTAINER_APP_NAME" >/dev/null 2>&1; then
+            az containerapp secret set \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_CONTAINER_APP_NAME" \
+              --secrets \
+                database-url="$DATABASE_URL" \
+                redis-url="$REDIS_URL" \
+                secret-key="$SECRET_KEY" \
+                apollo-api-key="$APOLLO_API_KEY" \
+                elevenlabs-api-key="$ELEVENLABS_API_KEY"
+
+            az containerapp update \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_CONTAINER_APP_NAME" \
+              --image "$IMAGE" \
+              --set-env-vars "${common_env[@]}"
+          else
+            az containerapp create \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_CONTAINER_APP_NAME" \
+              --environment "$AZURE_CONTAINER_APP_ENVIRONMENT" \
+              --location "$AZURE_LOCATION" \
+              --image "$IMAGE" \
+              --target-port 8000 \
+              --ingress external \
+              --min-replicas 1 \
+              --max-replicas 3 \
+              --secrets \
+                database-url="$DATABASE_URL" \
+                redis-url="$REDIS_URL" \
+                secret-key="$SECRET_KEY" \
+                apollo-api-key="$APOLLO_API_KEY" \
+                elevenlabs-api-key="$ELEVENLABS_API_KEY" \
+              --env-vars "${common_env[@]}"
+          fi
+
+      - name: Smoke test health endpoint
+        run: |
+          fqdn=$(az containerapp show \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_CONTAINER_APP_NAME" \
+            --query properties.configuration.ingress.fqdn \
+            --output tsv)
+          curl --fail --retry 12 --retry-delay 5 "https://${fqdn}/health"

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ EXPOSE 8000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD curl -f "http://localhost:${PORT:-8000}/health" || exit 1
 
 # Run application
-CMD ["uvicorn", "blank_business_builder.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+CMD ["sh", "-c", "uvicorn ${APP_MODULE:-blank_business_builder.main:app} --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-4}"]

--- a/docs/deployment/AZURE_CONTAINER_APPS.md
+++ b/docs/deployment/AZURE_CONTAINER_APPS.md
@@ -1,17 +1,20 @@
 # Azure Container Apps deployment
 
-This repo can deploy the FastAPI app to Azure Container Apps using
+This repo can deploy the public BBB API and the private Echo Prime orchestrator
+to Azure Container Apps using
 `.github/workflows/azure-container-app.yml`.
 
 ## Required GitHub variables
 
 - `AZURE_RESOURCE_GROUP`
-- `AZURE_CONTAINER_APP_NAME`
+- `AZURE_CONTAINER_APP_NAME` - public BBB FastAPI app
+- `AZURE_ECHO_PRIME_APP_NAME` - private Echo Prime app, defaults to `echo-prime`
 - `AZURE_CONTAINER_APP_ENVIRONMENT`
 - `AZURE_CONTAINER_REGISTRY` - ACR name without `.azurecr.io`
 - `AZURE_LOCATION` - optional, defaults to `eastus`
-- `ECHO_BASE_URL` - public app URL after DNS is assigned
 - `CORS_ORIGINS` - comma-separated allowed browser origins
+- `ECH0_LLM_PROVIDER` - optional, defaults to `ollama`
+- `ECH0_LLM_ENDPOINT` - optional cloud/private model endpoint
 
 ## Required GitHub secrets
 
@@ -21,10 +24,18 @@ This repo can deploy the FastAPI app to Azure Container Apps using
 - `REDIS_URL`
 - `APOLLO_API_KEY`
 - `ELEVENLABS_API_KEY`
+- `ECH0_LLM_API_KEY` - optional, only needed when the Echo Prime model endpoint requires it
 
 ## Runtime notes
 
-- The container listens on port `8000` and exposes `/health`.
+- The same image runs both services. `APP_MODULE` and `PORT` select the process:
+  - BBB API: `blank_business_builder.main:app` on port `8000`
+  - Echo Prime: `blank_business_builder.echo_prime_api:app` on port `8001`
+- Echo Prime is created with internal ingress so it is reachable from BBB inside
+  the Container Apps environment, but is not public.
+- BBB is created with external ingress and receives `ECHO_BASE_URL` and
+  `ECHO_PRIME_BASE_URL` from the private Echo Prime app FQDN.
+- Both services expose `/health`.
 - Apollo lead discovery is available at `/api/v1/outreach/discover`.
 - ElevenLabs voice asset generation is available at
   `/api/v1/outreach/create-elevenlabs-audio`.
@@ -33,3 +44,16 @@ This repo can deploy the FastAPI app to Azure Container Apps using
 
 The ElevenLabs endpoints require `consent_confirmed=true`; they create audio
 assets and database outreach records, but do not place outbound calls.
+
+## Echo Prime orchestration routes
+
+BBB calls Echo Prime through `EchoMasterBrain` for autonomous decisions:
+
+- `/internal/echo/outreach-decision`
+- `/internal/echo/post-call-decision`
+- `/v1/businesses/recommendations`
+- `/v1/businesses/validate`
+- `/v1/chat`
+
+If Echo Prime is temporarily unavailable, BBB still falls back to deterministic
+local heuristics so outreach workflows degrade safely instead of crashing.

--- a/docs/deployment/AZURE_CONTAINER_APPS.md
+++ b/docs/deployment/AZURE_CONTAINER_APPS.md
@@ -1,0 +1,35 @@
+# Azure Container Apps deployment
+
+This repo can deploy the FastAPI app to Azure Container Apps using
+`.github/workflows/azure-container-app.yml`.
+
+## Required GitHub variables
+
+- `AZURE_RESOURCE_GROUP`
+- `AZURE_CONTAINER_APP_NAME`
+- `AZURE_CONTAINER_APP_ENVIRONMENT`
+- `AZURE_CONTAINER_REGISTRY` - ACR name without `.azurecr.io`
+- `AZURE_LOCATION` - optional, defaults to `eastus`
+- `ECHO_BASE_URL` - public app URL after DNS is assigned
+- `CORS_ORIGINS` - comma-separated allowed browser origins
+
+## Required GitHub secrets
+
+- `AZURE_CREDENTIALS` - JSON credentials for `azure/login`
+- `SECRET_KEY`
+- `DATABASE_URL`
+- `REDIS_URL`
+- `APOLLO_API_KEY`
+- `ELEVENLABS_API_KEY`
+
+## Runtime notes
+
+- The container listens on port `8000` and exposes `/health`.
+- Apollo lead discovery is available at `/api/v1/outreach/discover`.
+- ElevenLabs voice asset generation is available at
+  `/api/v1/outreach/create-elevenlabs-audio`.
+- Batch Apollo discovery plus ElevenLabs voice drafts is available at
+  `/api/v1/outreach/discover-and-create-elevenlabs-audio`.
+
+The ElevenLabs endpoints require `consent_confirmed=true`; they create audio
+assets and database outreach records, but do not place outbound calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "PyJWT>=2.8.0",
     "passlib[bcrypt]>=1.7.4",
     "python-dotenv>=1.0.0",
+    "email-validator>=2.3.0",
 
     # Payment Processing
     "stripe>=9.6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ cryptography==42.0.0
 # Utilities
 pydantic==2.5.3
 pydantic-settings==2.1.0
+email-validator==2.3.0
 
 # Quantum Features Dependencies
 numpy==1.26.4

--- a/src/blank_business_builder/agents/voice_agent.py
+++ b/src/blank_business_builder/agents/voice_agent.py
@@ -5,8 +5,10 @@ Webhook-driven voice outreach orchestration around Bland call lifecycle.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urljoin
+from uuid import uuid4
 from sqlalchemy.orm import Session
 
 from ..config import settings
@@ -21,6 +23,7 @@ class VoiceAgent:
 
     def __init__(self) -> None:
         self.bland = IntegrationFactory.get_bland_service()
+        self.elevenlabs = IntegrationFactory.get_elevenlabs_service()
         self.slack = IntegrationFactory.get_slack_service()
         self.brain = EchoMasterBrain()
         self.default_persona_id = settings.BBB_PERSONA_ID
@@ -29,6 +32,12 @@ class VoiceAgent:
         self.default_max_duration = settings.BLAND_MAX_DURATION_MINUTES
         self.default_record_calls = settings.BLAND_RECORD_CALLS
         self.default_wait_for_greeting = settings.BLAND_WAIT_FOR_GREETING
+
+    @staticmethod
+    def _safe_slug(value: str, *, fallback: str = "lead") -> str:
+        slug = "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-")
+        slug = "-".join(part for part in slug.split("-") if part)
+        return (slug or fallback)[:80]
 
     def _absolute_webhook(self, webhook_url: Optional[str]) -> str:
         """Resolve relative webhook paths against ECHO_BASE_URL when possible."""
@@ -134,6 +143,68 @@ class VoiceAgent:
             "outreach_attempt_id": str(outreach.id),
             "provider_call_id": provider_call_id,
             "call_response": call_response,
+        }
+
+    def create_elevenlabs_outreach_audio(
+        self,
+        db: Session,
+        *,
+        lead: LeadRecord,
+        script: str,
+        voice_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        output_dir: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a personalized ElevenLabs audio asset and persist an outreach attempt."""
+        if not script.strip():
+            raise ValueError("script is required")
+
+        outreach = OutreachAttempt(
+            lead_id=lead.id,
+            channel="voice_asset",
+            provider="elevenlabs",
+            status="queued",
+            task="Generate personalized voice outreach audio",
+            script=script,
+        )
+        db.add(outreach)
+        db.flush()
+
+        directory = Path(output_dir or settings.ELEVENLABS_OUTREACH_AUDIO_DIR)
+        lead_slug = self._safe_slug(lead.full_name or lead.company or str(lead.id))
+        output_path = directory / f"{lead_slug}-{uuid4().hex[:10]}.mp3"
+        written_path = self.elevenlabs.write_speech_file(
+            script,
+            output_path,
+            voice_id=voice_id,
+            model_id=model_id,
+        )
+
+        outreach.status = "completed"
+        outreach.completed_at = datetime.utcnow()
+        lead.status = "voice_asset_ready"
+        db.add(
+            ProviderEvent(
+                provider="elevenlabs",
+                event_type="text_to_speech.generated",
+                external_id=str(outreach.id),
+                payload={
+                    "lead_id": str(lead.id),
+                    "outreach_attempt_id": str(outreach.id),
+                    "audio_path": str(written_path),
+                    "voice_id": voice_id or settings.ELEVENLABS_VOICE_ID,
+                },
+                processed=True,
+                processed_at=datetime.utcnow(),
+            )
+        )
+        db.commit()
+        return {
+            "outreach_attempt_id": str(outreach.id),
+            "lead_id": str(lead.id),
+            "provider": "elevenlabs",
+            "audio_path": str(written_path),
+            "status": outreach.status,
         }
 
     def handle_post_call_webhook(

--- a/src/blank_business_builder/api/webhooks.py
+++ b/src/blank_business_builder/api/webhooks.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
@@ -52,10 +52,34 @@ class VoiceOutreachRequest(BaseModel):
     force_script: Optional[str] = None
 
 
+class ElevenLabsOutreachRequest(BaseModel):
+    lead_id: str
+    consent_confirmed: bool = Field(
+        False,
+        description="Operator confirms a lawful basis/consent for B2B outreach to this lead.",
+    )
+    force_script: Optional[str] = None
+    voice_id: Optional[str] = None
+    model_id: Optional[str] = None
+
+
 class ApolloDiscoverRequest(BaseModel):
     keywords: str = Field(..., description="Search terms for Apollo people search")
     organization_name: Optional[str] = None
     per_page: int = 10
+
+
+class ApolloVoiceDraftRequest(ApolloDiscoverRequest):
+    consent_confirmed: bool = Field(
+        False,
+        description="Operator confirms a lawful basis/consent before generating outreach audio.",
+    )
+    voice_id: Optional[str] = None
+    model_id: Optional[str] = None
+    b2b_site_queries: List[str] = Field(
+        default_factory=list,
+        description="Optional extra B2B directory/site keywords to append to the Apollo search.",
+    )
 
 
 def _get_route_channel(db: Session, department: str) -> Optional[str]:
@@ -238,6 +262,108 @@ async def create_outreach_call(request: VoiceOutreachRequest, db: Session = Depe
         task=request.force_task or str(decision.get("task") or ""),
     )
     return {"ok": True, "decision": decision, "result": result}
+
+
+@router.post("/v1/outreach/create-elevenlabs-audio")
+async def create_elevenlabs_audio(request: ElevenLabsOutreachRequest, db: Session = Depends(get_db)):
+    """
+    Generate a personalized ElevenLabs voice asset for a lead.
+
+    This endpoint creates an audio asset for lawful B2B outreach workflows; it does not
+    place outbound calls. The caller must confirm consent/lawful basis before generation.
+    """
+    if not request.consent_confirmed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="consent_confirmed must be true before creating outreach audio",
+        )
+
+    lead = db.query(LeadRecord).filter(LeadRecord.id == request.lead_id).first()
+    if not lead:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Lead not found")
+    if not (lead.email or lead.phone):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Lead must have an email or phone before outreach audio is generated",
+        )
+
+    brain = EchoMasterBrain()
+    decision = brain.decide_outreach(
+        {
+            "lead_id": str(lead.id),
+            "full_name": lead.full_name,
+            "title": lead.title,
+            "company": lead.company,
+            "email": lead.email,
+            "phone": lead.phone,
+        }
+    )
+    script = request.force_script or str(decision.get("script") or decision.get("task") or "")
+    if not script.strip():
+        script = (
+            f"Hi {lead.full_name or 'there'}, this is a quick note for "
+            f"{lead.company or 'your team'} about improving B2B growth workflows. "
+            "If this is relevant, please reply and we can schedule a short conversation."
+        )
+
+    voice = VoiceAgent()
+    try:
+        result = voice.create_elevenlabs_outreach_audio(
+            db,
+            lead=lead,
+            script=script,
+            voice_id=request.voice_id,
+            model_id=request.model_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return {"ok": True, "decision": decision, "result": result}
+
+
+@router.post("/v1/outreach/discover-and-create-elevenlabs-audio")
+async def discover_and_create_elevenlabs_audio(
+    payload: ApolloVoiceDraftRequest, db: Session = Depends(get_db)
+):
+    """
+    Discover leads via Apollo search terms (optionally expanded with B2B site keywords)
+    and generate ElevenLabs audio assets for stored leads with contact information.
+    """
+    if not payload.consent_confirmed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="consent_confirmed must be true before creating outreach audio",
+        )
+
+    expanded_keywords = " ".join(
+        [payload.keywords] + [query.strip() for query in payload.b2b_site_queries if query.strip()]
+    ).strip()
+    discover_payload = ApolloDiscoverRequest(
+        keywords=expanded_keywords or payload.keywords,
+        organization_name=payload.organization_name,
+        per_page=min(payload.per_page, 10),
+    )
+    discover_result = await discover_and_store_leads(discover_payload, db)
+
+    generated = []
+    for item in discover_result["stored"]:
+        lead = db.query(LeadRecord).filter(LeadRecord.id == item["lead_id"]).first()
+        if not lead or not (lead.email or lead.phone):
+            continue
+        audio_request = ElevenLabsOutreachRequest(
+            lead_id=str(lead.id),
+            consent_confirmed=True,
+            voice_id=payload.voice_id,
+            model_id=payload.model_id,
+        )
+        audio_result = await create_elevenlabs_audio(audio_request, db)
+        generated.append(audio_result["result"])
+
+    return {
+        "ok": True,
+        "discovered": discover_result,
+        "generated": generated,
+        "count": len(generated),
+    }
 
 
 @router.get("/v1/outreach/calls/{provider_call_id}")

--- a/src/blank_business_builder/config.py
+++ b/src/blank_business_builder/config.py
@@ -36,6 +36,13 @@ class Config:
     TWILIO_FROM_NUMBER = os.getenv("TWILIO_FROM_NUMBER", "")
 
     ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY", "")
+    ELEVENLABS_BASE_URL = os.getenv("ELEVENLABS_BASE_URL", "https://api.elevenlabs.io")
+    ELEVENLABS_VOICE_ID = os.getenv("ELEVENLABS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM")
+    ELEVENLABS_MODEL_ID = os.getenv("ELEVENLABS_MODEL_ID", "eleven_multilingual_v2")
+    ELEVENLABS_OUTPUT_FORMAT = os.getenv("ELEVENLABS_OUTPUT_FORMAT", "mp3_44100_128")
+    ELEVENLABS_OUTREACH_AUDIO_DIR = os.getenv(
+        "ELEVENLABS_OUTREACH_AUDIO_DIR", "data/outreach_audio"
+    )
     
     TWITTER_CONSUMER_KEY = os.getenv("TWITTER_CONSUMER_KEY", "")
     TWITTER_CONSUMER_SECRET = os.getenv("TWITTER_CONSUMER_SECRET", "")

--- a/src/blank_business_builder/echo_master_brain.py
+++ b/src/blank_business_builder/echo_master_brain.py
@@ -24,7 +24,9 @@ class EchoMasterBrain:
         timeout_seconds: int = 15,
         session: Optional[requests.Session] = None,
     ) -> None:
-        self.base_url = (base_url or os.getenv("ECHO_BASE_URL", "")).rstrip("/")
+        if base_url is None:
+            base_url = os.getenv("ECHO_PRIME_BASE_URL") or os.getenv("ECHO_BASE_URL", "")
+        self.base_url = base_url.rstrip("/")
         self.timeout_seconds = timeout_seconds
         self.session = session or requests.Session()
 

--- a/src/blank_business_builder/integrations/__init__.py
+++ b/src/blank_business_builder/integrations/__init__.py
@@ -4,6 +4,7 @@ Public integrations package exports.
 
 from .apollo import ApolloService
 from .bland import BlandService
+from .elevenlabs import ElevenLabsService
 from .legacy import (
     AnthropicService,
     BufferService,
@@ -22,6 +23,7 @@ __all__ = [
     "BlandService",
     "BufferService",
     "ECH0Service",
+    "ElevenLabsService",
     "IntegrationContainer",
     "IntegrationFactory",
     "OpenAIService",

--- a/src/blank_business_builder/integrations/elevenlabs.py
+++ b/src/blank_business_builder/integrations/elevenlabs.py
@@ -1,0 +1,102 @@
+"""
+ElevenLabs text-to-speech integration for voice outreach assets.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import requests
+
+
+class ElevenLabsService:
+    """Thin API client for ElevenLabs text-to-speech generation."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        default_voice_id: Optional[str] = None,
+        default_model_id: Optional[str] = None,
+        output_format: Optional[str] = None,
+        timeout_seconds: int = 30,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.api_key = api_key or os.getenv("ELEVENLABS_API_KEY", "")
+        self.base_url = (
+            base_url or os.getenv("ELEVENLABS_BASE_URL", "https://api.elevenlabs.io")
+        ).rstrip("/")
+        self.default_voice_id = default_voice_id or os.getenv(
+            "ELEVENLABS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM"
+        )
+        self.default_model_id = default_model_id or os.getenv(
+            "ELEVENLABS_MODEL_ID", "eleven_multilingual_v2"
+        )
+        self.output_format = output_format or os.getenv(
+            "ELEVENLABS_OUTPUT_FORMAT", "mp3_44100_128"
+        )
+        self.timeout_seconds = timeout_seconds
+        self.session = session or requests.Session()
+
+    def text_to_speech(
+        self,
+        text: str,
+        *,
+        voice_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        output_format: Optional[str] = None,
+        voice_settings: Optional[Dict[str, Any]] = None,
+    ) -> bytes:
+        """Generate audio bytes from text."""
+        if not self.api_key:
+            raise ValueError("ELEVENLABS_API_KEY is required")
+        if not text.strip():
+            raise ValueError("text is required")
+
+        selected_voice = voice_id or self.default_voice_id
+        selected_format = output_format or self.output_format
+        payload: Dict[str, Any] = {
+            "text": text,
+            "model_id": model_id or self.default_model_id,
+        }
+        if voice_settings:
+            payload["voice_settings"] = voice_settings
+
+        response = self.session.post(
+            url=f"{self.base_url}/v1/text-to-speech/{selected_voice}",
+            params={"output_format": selected_format},
+            json=payload,
+            headers={
+                "xi-api-key": self.api_key,
+                "Content-Type": "application/json",
+                "Accept": "audio/mpeg",
+            },
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        return bytes(response.content)
+
+    def write_speech_file(
+        self,
+        text: str,
+        output_path: Union[str, Path],
+        *,
+        voice_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        output_format: Optional[str] = None,
+        voice_settings: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        """Generate speech and persist it to a local file."""
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        audio = self.text_to_speech(
+            text,
+            voice_id=voice_id,
+            model_id=model_id,
+            output_format=output_format,
+            voice_settings=voice_settings,
+        )
+        path.write_bytes(audio)
+        return path

--- a/src/blank_business_builder/integrations/service.py
+++ b/src/blank_business_builder/integrations/service.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from .apollo import ApolloService
 from .bland import BlandService
+from .elevenlabs import ElevenLabsService
 from .legacy import (
     AnthropicService,
     BufferService,
@@ -28,6 +29,7 @@ class IntegrationContainer:
 
     bland: BlandService = field(default_factory=BlandService)
     apollo: ApolloService = field(default_factory=ApolloService)
+    elevenlabs: ElevenLabsService = field(default_factory=ElevenLabsService)
     slack: SlackService = field(default_factory=SlackService)
 
 
@@ -51,6 +53,10 @@ class IntegrationFactory(LegacyIntegrationFactory):
         return cls.get_container().apollo
 
     @classmethod
+    def get_elevenlabs_service(cls) -> ElevenLabsService:
+        return cls.get_container().elevenlabs
+
+    @classmethod
     def get_slack_service(cls) -> SlackService:
         return cls.get_container().slack
 
@@ -66,6 +72,7 @@ __all__ = [
     "BlandService",
     "BufferService",
     "ECH0Service",
+    "ElevenLabsService",
     "IntegrationContainer",
     "IntegrationFactory",
     "OpenAIService",

--- a/tests/test_echo_prime_cloud_integration.py
+++ b/tests/test_echo_prime_cloud_integration.py
@@ -2,8 +2,39 @@ from fastapi.testclient import TestClient
 
 from src.blank_business_builder.bbb_unified_business_library import BBBUnifiedLibrary
 from src.blank_business_builder.config import settings
+from src.blank_business_builder.echo_master_brain import EchoMasterBrain
 from src.blank_business_builder.echo_prime_api import app as echo_prime_app
 from src.blank_business_builder.main import app as bbb_app
+
+
+class _FakeResponse:
+    content = b"{}"
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {
+            "department": "exec",
+            "outreach_priority": 99,
+            "task": "Route to executive orchestrator",
+        }
+
+
+class _FakeSession:
+    def __init__(self):
+        self.posts = []
+
+    def post(self, url, json, timeout, headers):
+        self.posts.append(
+            {
+                "url": url,
+                "json": json,
+                "timeout": timeout,
+                "headers": headers,
+            }
+        )
+        return _FakeResponse()
 
 
 def test_packaged_unified_library_loads_cloud_data():
@@ -36,6 +67,31 @@ def test_echo_prime_service_exposes_recommendations():
     assert recommendations
     assert "business" in recommendations[0]
     assert "match_score" in recommendations[0]
+
+
+def test_echo_master_brain_prefers_echo_prime_base_url(monkeypatch):
+    monkeypatch.setenv("ECHO_BASE_URL", "https://bbb.example.com")
+    monkeypatch.setenv("ECHO_PRIME_BASE_URL", "https://echo-prime.internal")
+    session = _FakeSession()
+
+    decision = EchoMasterBrain(session=session).decide_outreach(
+        {"full_name": "Alex Rivera", "company": "Acme", "phone": "+15555551212"}
+    )
+
+    assert decision["department"] == "exec"
+    assert session.posts[0]["url"] == "https://echo-prime.internal/internal/echo/outreach-decision"
+
+
+def test_echo_master_brain_explicit_empty_base_url_disables_remote_calls(monkeypatch):
+    monkeypatch.setenv("ECHO_PRIME_BASE_URL", "https://echo-prime.internal")
+    session = _FakeSession()
+
+    decision = EchoMasterBrain(base_url="", session=session).decide_outreach(
+        {"full_name": "Alex Rivera", "company": "Acme", "phone": "+15555551212"}
+    )
+
+    assert session.posts == []
+    assert decision["department"] == "sales"
 
 
 def test_bbb_api_exposes_echo_prime_health():

--- a/tests/test_elevenlabs_integration.py
+++ b/tests/test_elevenlabs_integration.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.blank_business_builder.agents.voice_agent import VoiceAgent
+from src.blank_business_builder.database import Base, LeadRecord, OutreachAttempt, ProviderEvent
+from src.blank_business_builder.integrations.elevenlabs import ElevenLabsService
+
+
+class _FakeResponse:
+    content = b"audio-bytes"
+
+    def raise_for_status(self):
+        return None
+
+
+class _FakeSession:
+    def __init__(self):
+        self.posts = []
+
+    def post(self, url, params, json, headers, timeout):
+        self.posts.append(
+            {
+                "url": url,
+                "params": params,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return _FakeResponse()
+
+
+class _FakeElevenLabs:
+    def __init__(self):
+        self.calls = []
+
+    def write_speech_file(self, text, output_path, voice_id=None, model_id=None):
+        self.calls.append(
+            {
+                "text": text,
+                "output_path": Path(output_path),
+                "voice_id": voice_id,
+                "model_id": model_id,
+            }
+        )
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(b"audio-bytes")
+        return Path(output_path)
+
+
+class _FakeBland:
+    pass
+
+
+class _FakeSlack:
+    pass
+
+
+def test_elevenlabs_text_to_speech_posts_expected_payload():
+    session = _FakeSession()
+    service = ElevenLabsService(
+        api_key="eleven-key",
+        default_voice_id="voice-123",
+        default_model_id="model-123",
+        session=session,
+    )
+
+    audio = service.text_to_speech("Hello Alex")
+
+    assert audio == b"audio-bytes"
+    assert len(session.posts) == 1
+    post = session.posts[0]
+    assert post["url"].endswith("/v1/text-to-speech/voice-123")
+    assert post["params"] == {"output_format": "mp3_44100_128"}
+    assert post["json"] == {"text": "Hello Alex", "model_id": "model-123"}
+    assert post["headers"]["xi-api-key"] == "eleven-key"
+
+
+def test_voice_agent_creates_elevenlabs_outreach_asset(monkeypatch, tmp_path):
+    engine = create_engine("sqlite:///:memory:")
+    TestingSession = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    db = TestingSession()
+
+    lead = LeadRecord(
+        full_name="Alex Rivera",
+        company="Acme",
+        email="alex@acme.com",
+        status="new",
+    )
+    db.add(lead)
+    db.commit()
+    db.refresh(lead)
+
+    fake_elevenlabs = _FakeElevenLabs()
+    monkeypatch.setattr(
+        "src.blank_business_builder.agents.voice_agent.IntegrationFactory.get_bland_service",
+        Mock(return_value=_FakeBland()),
+    )
+    monkeypatch.setattr(
+        "src.blank_business_builder.agents.voice_agent.IntegrationFactory.get_elevenlabs_service",
+        Mock(return_value=fake_elevenlabs),
+    )
+    monkeypatch.setattr(
+        "src.blank_business_builder.agents.voice_agent.IntegrationFactory.get_slack_service",
+        Mock(return_value=_FakeSlack()),
+    )
+
+    voice = VoiceAgent()
+    result = voice.create_elevenlabs_outreach_audio(
+        db,
+        lead=lead,
+        script="Hi Alex, this is a short B2B follow-up.",
+        voice_id="voice-456",
+        model_id="model-456",
+        output_dir=str(tmp_path),
+    )
+
+    assert result["provider"] == "elevenlabs"
+    assert result["status"] == "completed"
+    assert Path(result["audio_path"]).exists()
+    assert fake_elevenlabs.calls[0]["voice_id"] == "voice-456"
+
+    attempt = db.query(OutreachAttempt).filter(OutreachAttempt.lead_id == lead.id).one()
+    event = db.query(ProviderEvent).filter(ProviderEvent.provider == "elevenlabs").one()
+    db.refresh(lead)
+    assert attempt.channel == "voice_asset"
+    assert attempt.status == "completed"
+    assert event.processed is True
+    assert lead.status == "voice_asset_ready"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Azure Container Apps deployment workflow and deployment documentation.
- Deploy both the public BBB API and private Echo Prime orchestrator from the same image.
- Make the Docker image module/port configurable with `APP_MODULE`, `PORT`, and `WEB_CONCURRENCY` so Azure can run BBB on 8000 and Echo Prime on 8001.
- Point BBB at the private Echo Prime Container App through `ECHO_BASE_URL` / `ECHO_PRIME_BASE_URL`.
- Add first-class ElevenLabs text-to-speech integration and compliant voice-asset outreach endpoints for stored Apollo leads and capped Apollo discovery batches.
- Add `email-validator` as a runtime dependency for Pydantic `EmailStr` routes.
- Add focused tests for ElevenLabs request payloads, outreach asset persistence, and Echo Prime orchestrator URL handling.

## Testing
- `.venv/bin/python -m pytest tests/test_echo_prime_cloud_integration.py tests/test_elevenlabs_integration.py tests/test_apollo_integration.py tests/test_outreach_flow.py -q`
- `docker build -t bbb-azure-echo-prime-test .` could not be run in this runner because Docker is not installed (`docker: command not found`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e2a8ed5-db29-43b0-a770-cf143366ab1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e2a8ed5-db29-43b0-a770-cf143366ab1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

