### PR TITLE
⚡ Bolt: Optimize database connection caching for get_db()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+## 2026-03-05 - Optimize SQLAlchemy Engine and Session Maker Caching
+**Learning:** Creating a SQLAlchemy engine (`create_engine()`) directly inside a FastAPI dependency generator like `get_db()` breaks connection pooling by creating a new pool per request. This causes major performance regressions due to constant connection setup/teardown.
+**Action:** Always lazily cache the database engine and session maker globally (e.g., using a singleton pattern or module-level dictionary) to ensure they are reused across requests, preserving the connection pool.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,3 +1,4 @@
-🎯 **What:** Adds unit tests for the asynchronous `run_autonomous_loop` and `launch_magic_rd_lab_business` functions in `magic_rd_lab_autonomous_agents.py`. The infinite loop and sleeping functionality are mocked to allow fast, deterministic tests without running into timeout issues.
-📊 **Coverage:** Covered loop entry, loop exit conditions via mocked exceptions, agent deployments, invocation of underlying methods, and ensuring metrics sum exactly appropriately after 1 pass through the loop.
-✨ **Result:** Enhanced test coverage that protects core async loop functionality from regressions.
+💡 What: Implement lazy caching (singletons) for the database engine and session maker in `src/blank_business_builder/database.py`. The `get_db_engine` and `get_session_maker` functions will now return cached instances.
+🎯 Why: `get_db()` is a FastAPI dependency called repeatedly (on every database-involved API request). Previously, `get_db_engine()` created a *new* SQLAlchemy engine on every request. This caused major performance regressions by preventing connection pooling entirely and tearing down/creating new connection pools constantly.
+📊 Impact: Expected significant reduction in database connection overhead and response time for all requests relying on `get_db()`.
+🔬 Measurement: Verify tests run successfully. Inspect database connections during application use. Run `python3 run_test_database.py`.

--- a/src/blank_business_builder/database.py
+++ b/src/blank_business_builder/database.py
@@ -421,23 +421,31 @@ class DepartmentRoute(Base):
 
 
 # Database connection helpers
+_engines = {}
+
 def get_db_engine(database_url: Optional[str] = None):
     """Create database engine"""
     if database_url is None:
         database_url = os.environ.get("DATABASE_URL", "postgresql://bbbuser:password@localhost:5432/bbb_production")
 
-    return create_engine(
-        database_url,
-        pool_pre_ping=True,  # Verify connections before use
-        pool_size=10,  # Connection pool size
-        max_overflow=20,  # Max connections beyond pool_size
-        echo=False  # Set to True for SQL logging
-    )
+    if database_url not in _engines:
+        _engines[database_url] = create_engine(
+            database_url,
+            pool_pre_ping=True,  # Verify connections before use
+            pool_size=10,  # Connection pool size
+            max_overflow=20,  # Max connections beyond pool_size
+            echo=False  # Set to True for SQL logging
+        )
+    return _engines[database_url]
 
+
+_session_makers = {}
 
 def get_session_maker(engine):
     """Create session maker"""
-    return sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    if engine not in _session_makers:
+        _session_makers[engine] = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    return _session_makers[engine]
 
 
 def get_session(engine):


### PR DESCRIPTION
💡 What: Implement lazy caching (singletons) for the database engine and session maker in `src/blank_business_builder/database.py`. The `get_db_engine` and `get_session_maker` functions will now return cached instances.
🎯 Why: `get_db()` is a FastAPI dependency called repeatedly (on every database-involved API request). Previously, `get_db_engine()` created a *new* SQLAlchemy engine on every request. This caused major performance regressions by preventing connection pooling entirely and tearing down/creating new connection pools constantly. 
📊 Impact: Expected significant reduction in database connection overhead and response time for all requests relying on `get_db()`.
🔬 Measurement: Verify tests run successfully. Inspect database connections during application use. Run `python3 run_test_database.py`.

---
*PR created automatically by Jules for task [2928193000513475088](https://jules.google.com/task/2928193000513475088) started by @Workofarttattoo*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes database connection lifecycle by introducing global engine/sessionmaker caches; mistakes could cause stale connections, unexpected cross-env reuse, or memory growth if many URLs/engines are created. Logic is small but affects all DB-backed requests and recovery paths that dispose/recreate engines.
> 
> **Overview**
> **Improves DB performance by reusing connection pools across requests.** `get_db_engine()` now lazily caches engines per `database_url`, and `get_session_maker()` caches sessionmakers per engine, avoiding per-request `create_engine()`/`sessionmaker()` construction.
> 
> Also updates internal Bolt notes/PR description text to document the new guidance around engine/sessionmaker caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7860661eb070fa8766267c8545c43d051fa3f9c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->