### PR TITLE
⚡ Bolt: Optimize get_business_metrics in MagicRDLab to a single O(N) pass

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+## 2026-03-04 - Optimize MagicRDLab Metrics Gathering
+**Learning:** In `get_business_metrics` for the `MagicRDLab` class, multiple generator expressions and list comprehensions were used sequentially to filter `active_sessions`, `completed_sessions`, build a `package_dist` map, and sum `total_computations`. This causes 6 separate O(N) traversals over the same `self.sessions` list, which degrades performance unnecessarily when scaling sessions.
+**Action:** Consolidate multiple list traversals over the same dataset into a single O(N) `for` loop that computes all required aggregations simultaneously to improve execution speed and reduce event loop blocking.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,3 +1,4 @@
-🎯 **What:** Adds unit tests for the asynchronous `run_autonomous_loop` and `launch_magic_rd_lab_business` functions in `magic_rd_lab_autonomous_agents.py`. The infinite loop and sleeping functionality are mocked to allow fast, deterministic tests without running into timeout issues.
-📊 **Coverage:** Covered loop entry, loop exit conditions via mocked exceptions, agent deployments, invocation of underlying methods, and ensuring metrics sum exactly appropriately after 1 pass through the loop.
-✨ **Result:** Enhanced test coverage that protects core async loop functionality from regressions.
+💡 What: Refactored `get_business_metrics` in `MagicRDLab` to use a single O(N) `for` loop instead of multiple sequential list comprehensions and generator expressions.
+🎯 Why: Iterating over `self.sessions` 6 times sequentially scales poorly and blocks the event loop unnecessarily as the number of sessions grows.
+📊 Impact: Reduces the number of traversals from 6 to 1, cutting down time complexity constant factors and saving memory allocation by avoiding intermediary lists.
+🔬 Measurement: Verify tests still pass using `python3 run_test.py`. Execution of metric gathering on large session lists will observe a 6x reduction in traversal operations.

--- a/src/blank_business_builder/magic_rd_lab.py
+++ b/src/blank_business_builder/magic_rd_lab.py
@@ -347,24 +347,33 @@ class MagicRDLab:
 
     def get_business_metrics(self) -> Dict[str, Any]:
         """Get business performance metrics."""
-        active_sessions = [s for s in self.sessions if s.status == "active"]
-        completed_sessions = [s for s in self.sessions if s.status == "completed"]
+        # ⚡ Bolt Optimization: Calculate totals in a single O(N) pass
+        # instead of multiple generator expressions and list comprehensions
+        active_sessions_count = 0
+        completed_sessions_count = 0
+        package_dist = {pkg.value: 0 for pkg in RentalPackage}
+        total_computations = 0
 
-        # Package distribution
-        package_dist = {}
-        for package in RentalPackage:
-            count = len([s for s in self.sessions if s.package == package])
-            package_dist[package.value] = count
+        for s in self.sessions:
+            if s.status == "active":
+                active_sessions_count += 1
+            elif s.status == "completed":
+                completed_sessions_count += 1
+
+            if s.package.value in package_dist:
+                package_dist[s.package.value] += 1
+
+            total_computations += len(s.results)
 
         return {
             "total_revenue": float(self.revenue),
             "total_customers": len(self.customers),
             "total_sessions": len(self.sessions),
-            "active_sessions": len(active_sessions),
-            "completed_sessions": len(completed_sessions),
+            "active_sessions": active_sessions_count,
+            "completed_sessions": completed_sessions_count,
             "package_distribution": package_dist,
             "avg_revenue_per_customer": float(self.revenue / max(1, len(self.customers))),
-            "total_computations": sum(len(s.results) for s in self.sessions)
+            "total_computations": total_computations
         }
 
 


### PR DESCRIPTION
💡 What: Refactored `get_business_metrics` in `MagicRDLab` to use a single O(N) `for` loop instead of multiple sequential list comprehensions and generator expressions.
🎯 Why: Iterating over `self.sessions` 6 times sequentially scales poorly and blocks the event loop unnecessarily as the number of sessions grows.
📊 Impact: Reduces the number of traversals from 6 to 1, cutting down time complexity constant factors and saving memory allocation by avoiding intermediary lists.
🔬 Measurement: Verify tests still pass using `python3 run_test.py`. Execution of metric gathering on large session lists will observe a 6x reduction in traversal operations.

---
*PR created automatically by Jules for task [16158507656847551420](https://jules.google.com/task/16158507656847551420) started by @Workofarttattoo*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor limited to `MagicRDLab.get_business_metrics`, but it changes aggregation logic and could subtly affect counts if edge cases were missed.
> 
> **Overview**
> Refactors `MagicRDLab.get_business_metrics` to compute session status counts, package distribution, and `total_computations` in a single pass over `self.sessions`, replacing multiple list comprehensions/generator traversals.
> 
> Updates accompanying PR notes (`pr_body.txt`) and Bolt optimization log (`.jules/bolt.md`) to document the change and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13153d76bb15b5ae9fd5a6485031dfe0df8250c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->