### PR TITLE
⚡ Bolt: Optimize magic_rd_lab metric gathering functions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+## 2025-01-20 - [Optimize dashboard metric gathering]
+**Learning:** Sequential list comprehensions and generator expressions over the same collection during metric aggregation create redundant traversals and memory allocations that can impact synchronous endpoint performance under load.
+**Action:** Replace multiple sequential comprehensions with a single O(N) `for` loop to filter and aggregate multiple metric values simultaneously.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,3 +1,11 @@
-🎯 **What:** Adds unit tests for the asynchronous `run_autonomous_loop` and `launch_magic_rd_lab_business` functions in `magic_rd_lab_autonomous_agents.py`. The infinite loop and sleeping functionality are mocked to allow fast, deterministic tests without running into timeout issues.
-📊 **Coverage:** Covered loop entry, loop exit conditions via mocked exceptions, agent deployments, invocation of underlying methods, and ensuring metrics sum exactly appropriately after 1 pass through the loop.
-✨ **Result:** Enhanced test coverage that protects core async loop functionality from regressions.
+💡 What:
+Replaced multiple sequential list comprehensions and generator expressions in `get_business_metrics` and `get_customer_dashboard` of `MagicRDLab` with a single O(N) `for` loop that iterates over the `self.sessions` collection once to gather all necessary metrics concurrently.
+
+🎯 Why:
+To prevent redundant memory allocation and reduce event loop blocking. Prior implementation traversed the entire `self.sessions` list multiple times independently to compute active sessions, completed sessions, total computations, and package distributions, generating intermediate arrays and negatively impacting overall performance as session volume scales.
+
+📊 Impact:
+Reduces session traversal overhead by O(K*N) to O(N) where K is the number of distinct metrics computed, lowering dashboard load times and reducing transient memory spikes during metric generation.
+
+🔬 Measurement:
+No regressions expected. Dashboard loading times and system overhead can be profiled when rendering real-time views in production. Tests and manual invocation confirmed that logic correctly matches the sum of previous separate comprehensions.

--- a/src/blank_business_builder/magic_rd_lab.py
+++ b/src/blank_business_builder/magic_rd_lab.py
@@ -246,17 +246,24 @@ class MagicRDLab:
         if not customer:
             raise ValueError(f"Customer {customer_id} not found")
 
-        customer_sessions = [s for s in self.sessions if s.customer_email == customer.email]
-        active_sessions = [s for s in customer_sessions if s.status == "active"]
-        completed_sessions = [s for s in customer_sessions if s.status == "completed"]
-
-        # ⚡ Bolt Optimization: Calculate totals in a single O(N) pass
-        # instead of multiple generator expressions to improve dashboard load time
+        # ⚡ Bolt Optimization: Filter and calculate totals in a single O(N) pass
+        # over all sessions to improve dashboard load time, instead of multiple list comprehensions
         total_hours = 0
         total_computations = 0
-        for s in customer_sessions:
-            total_hours += PACKAGE_PRICING[s.package]["hours"]
-            total_computations += len(s.results)
+        active_sessions = []
+        customer_sessions_count = 0
+        completed_sessions_count = 0
+
+        for s in self.sessions:
+            if s.customer_email == customer.email:
+                customer_sessions_count += 1
+                total_hours += PACKAGE_PRICING[s.package]["hours"]
+                total_computations += len(s.results)
+
+                if s.status == "active":
+                    active_sessions.append(s)
+                elif s.status == "completed":
+                    completed_sessions_count += 1
 
         return {
             "customer_id": customer.customer_id,
@@ -267,14 +274,14 @@ class MagicRDLab:
             "member_since": customer.created_at.isoformat(),
             "total_spent": float(customer.total_spent),
             "sessions": {
-                "total": len(customer_sessions),
+                "total": customer_sessions_count,
                 "active": len(active_sessions),
-                "completed": len(completed_sessions)
+                "completed": completed_sessions_count
             },
             "usage": {
                 "total_hours_purchased": total_hours,
                 "total_computations": total_computations,
-                "avg_computations_per_session": total_computations / max(1, len(customer_sessions))
+                "avg_computations_per_session": total_computations / max(1, customer_sessions_count)
             },
             "active_sessions": [
                 {
@@ -347,24 +354,33 @@ class MagicRDLab:
 
     def get_business_metrics(self) -> Dict[str, Any]:
         """Get business performance metrics."""
-        active_sessions = [s for s in self.sessions if s.status == "active"]
-        completed_sessions = [s for s in self.sessions if s.status == "completed"]
+        # ⚡ Bolt Optimization: Single O(N) pass over sessions instead of
+        # multiple list comprehensions and generator expressions
+        active_sessions_count = 0
+        completed_sessions_count = 0
+        total_computations = 0
 
-        # Package distribution
-        package_dist = {}
-        for package in RentalPackage:
-            count = len([s for s in self.sessions if s.package == package])
-            package_dist[package.value] = count
+        # Initialize package distribution
+        package_dist = {package.value: 0 for package in RentalPackage}
+
+        for s in self.sessions:
+            if s.status == "active":
+                active_sessions_count += 1
+            elif s.status == "completed":
+                completed_sessions_count += 1
+
+            package_dist[s.package.value] += 1
+            total_computations += len(s.results)
 
         return {
             "total_revenue": float(self.revenue),
             "total_customers": len(self.customers),
             "total_sessions": len(self.sessions),
-            "active_sessions": len(active_sessions),
-            "completed_sessions": len(completed_sessions),
+            "active_sessions": active_sessions_count,
+            "completed_sessions": completed_sessions_count,
             "package_distribution": package_dist,
             "avg_revenue_per_customer": float(self.revenue / max(1, len(self.customers))),
-            "total_computations": sum(len(s.results) for s in self.sessions)
+            "total_computations": total_computations
         }
 
 


### PR DESCRIPTION
💡 What:
Replaced multiple sequential list comprehensions and generator expressions in `get_business_metrics` and `get_customer_dashboard` of `MagicRDLab` with a single O(N) `for` loop that iterates over the `self.sessions` collection once to gather all necessary metrics concurrently.

🎯 Why:
To prevent redundant memory allocation and reduce event loop blocking. Prior implementation traversed the entire `self.sessions` list multiple times independently to compute active sessions, completed sessions, total computations, and package distributions, generating intermediate arrays and negatively impacting overall performance as session volume scales.

📊 Impact:
Reduces session traversal overhead by O(K*N) to O(N) where K is the number of distinct metrics computed, lowering dashboard load times and reducing transient memory spikes during metric generation.

🔬 Measurement:
No regressions expected. Dashboard loading times and system overhead can be profiled when rendering real-time views in production. Tests and manual invocation confirmed that logic correctly matches the sum of previous separate comprehensions.

---
*PR created automatically by Jules for task [3812018098792204272](https://jules.google.com/task/3812018098792204272) started by @Workofarttattoo*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized performance refactor that should preserve existing metric outputs; main risk is subtle count/aggregation regressions for session status/package totals.
> 
> **Overview**
> Improves `MagicRDLab` metric generation by replacing repeated list comprehensions/generator expressions with a **single O(N) loop** in `get_customer_dashboard` and `get_business_metrics`, aggregating session counts, package distribution, and computation totals in one traversal.
> 
> Adds a corresponding entry to `.jules/bolt.md` documenting the optimization approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd324ab32ba8a335548c7221179295151551955a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->