### PR TITLE
⚡ Bolt: Fix N+1 queries in Level6Agent autonomous loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+## 2024-05-18 - [Resolve N+1 Queries in Level6Agent loops]
+**Learning:** Found explicit N+1 queries using COUNT inside loops and implicit N+1 queries from lazy-loaded relationships (`user.businesses`) in agent decision loops.
+**Action:** Pre-fetch aggregate stats and group by entity ID upfront using a dictionary or set lookup inside loop conditions rather than lazy relationship references or repeated DB COUNT calls.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,3 +1,7 @@
-🎯 **What:** Adds unit tests for the asynchronous `run_autonomous_loop` and `launch_magic_rd_lab_business` functions in `magic_rd_lab_autonomous_agents.py`. The infinite loop and sleeping functionality are mocked to allow fast, deterministic tests without running into timeout issues.
-📊 **Coverage:** Covered loop entry, loop exit conditions via mocked exceptions, agent deployments, invocation of underlying methods, and ensuring metrics sum exactly appropriately after 1 pass through the loop.
-✨ **Result:** Enhanced test coverage that protects core async loop functionality from regressions.
+💡 What: Refactored `manage_marketing_campaigns` and `manage_customer_lifecycle` in `src/blank_business_builder/level6_agent.py` to pre-fetch entity statuses before looping, resolving several implicit and explicit N+1 queries.
+
+🎯 Why: The autonomous decision loops were querying the database inside iterators (e.g., calling `.count()` on marketing campaigns for each active business or lazy-loading `user.businesses`). This blocks the event loop and significantly increases database roundtrips, degrading performance.
+
+📊 Impact: Reduces database queries per loop execution from O(N) to O(1) bulk fetch queries, which will substantially improve event-loop responsiveness under production workloads.
+
+🔬 Measurement: Execution times of the autonomous operations loops (especially `manage_marketing_campaigns`) should be monitored and will show much lower and consistent query counts in APM relative to the number of active users.

--- a/src/blank_business_builder/level6_agent.py
+++ b/src/blank_business_builder/level6_agent.py
@@ -113,29 +113,30 @@ class Level6Agent:
             business_counts = {user_id: count for user_id, count in counts}
 
         for user in users:
+            business_count = business_counts.get(user.id, 0)
+
             # Check if user needs onboarding
-            if self._needs_onboarding(user):
+            if self._needs_onboarding(user, business_count):
                 decision = await self._create_onboarding_sequence(user, db)
                 decisions.append(decision)
 
             # Check for upgrade opportunities
-            business_count = business_counts.get(user.id, 0)
             if self._should_suggest_upgrade(user, business_count):
                 decision = await self._create_upgrade_campaign(user, db)
                 decisions.append(decision)
 
             # Check engagement levels
-            if self._is_disengaged(user, db):
+            if self._is_disengaged(user):
                 decision = await self._create_reengagement_campaign(user, db)
                 decisions.append(decision)
 
         return decisions
 
-    def _needs_onboarding(self, user: User) -> bool:
+    def _needs_onboarding(self, user: User, business_count: int) -> bool:
         """Check if user needs onboarding."""
         # User created in last 7 days and hasn't created a business
         days_since_creation = (datetime.utcnow() - user.created_at).days
-        return days_since_creation <= 7 and not user.businesses
+        return days_since_creation <= 7 and business_count == 0
 
     async def _create_onboarding_sequence(self, user: User, db: Session) -> AgentDecision:
         """Create personalized onboarding email sequence."""
@@ -207,7 +208,7 @@ class Level6Agent:
             requires_approval=False
         )
 
-    def _is_disengaged(self, user: User, db: Session) -> bool:
+    def _is_disengaged(self, user: User) -> bool:
         """Check if user is disengaged."""
         if not user.last_login:
             return False
@@ -447,21 +448,22 @@ class Level6Agent:
         # Auto-generate marketing campaigns for businesses without recent campaigns
         businesses = db.query(Business).filter(Business.status == "active").all()
 
+        # Pre-fetch recent campaigns to avoid N+1 queries
+        business_ids = [b.id for b in businesses]
+        recent_campaign_business_ids = set()
+        if business_ids:
+            recent_campaigns = db.query(MarketingCampaign.business_id).filter(
+                MarketingCampaign.business_id.in_(business_ids),
+                MarketingCampaign.created_at > datetime.utcnow() - timedelta(days=30)
+            ).distinct().all()
+            recent_campaign_business_ids = {c[0] for c in recent_campaigns}
+
         for business in businesses:
-            if self._needs_marketing_campaign(business, db):
+            if business.id not in recent_campaign_business_ids:
                 decision = await self._create_auto_campaign(business, db)
                 decisions.append(decision)
 
         return decisions
-
-    def _needs_marketing_campaign(self, business: Business, db: Session) -> bool:
-        """Check if business needs a new marketing campaign."""
-        recent_campaigns = db.query(MarketingCampaign).filter(
-            MarketingCampaign.business_id == business.id,
-            MarketingCampaign.created_at > datetime.utcnow() - timedelta(days=30)
-        ).count()
-
-        return recent_campaigns == 0
 
     async def _create_auto_campaign(self, business: Business, db: Session) -> AgentDecision:
         """Automatically create marketing campaign for business."""


### PR DESCRIPTION
💡 What: Refactored `manage_marketing_campaigns` and `manage_customer_lifecycle` in `src/blank_business_builder/level6_agent.py` to pre-fetch entity statuses before looping, resolving several implicit and explicit N+1 queries.

🎯 Why: The autonomous decision loops were querying the database inside iterators (e.g., calling `.count()` on marketing campaigns for each active business or lazy-loading `user.businesses`). This blocks the event loop and significantly increases database roundtrips, degrading performance.

📊 Impact: Reduces database queries per loop execution from O(N) to O(1) bulk fetch queries, which will substantially improve event-loop responsiveness under production workloads.

🔬 Measurement: Execution times of the autonomous operations loops (especially `manage_marketing_campaigns`) should be monitored and will show much lower and consistent query counts in APM relative to the number of active users.

---
*PR created automatically by Jules for task [5008085498346209321](https://jules.google.com/task/5008085498346209321) started by @Workofarttattoo*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query patterns and decision conditions in autonomous loops; while intended to be equivalent, mistakes could alter which users/businesses get onboarding or marketing actions and could stress DB differently under edge cases.
> 
> **Overview**
> Reduces N+1 query patterns in `Level6Agent` autonomous loops by **bulk prefetching** per-user business counts in `manage_customer_lifecycle` (and using those counts in `_needs_onboarding`) instead of relying on `user.businesses` lazy loads.
> 
> Optimizes `manage_marketing_campaigns` by preloading the set of businesses with recent `MarketingCampaign`s and removing the per-business `.count()` query helper, so campaign creation checks are done via set membership.
> 
> Updates PR notes (`pr_body.txt`) and the Jules bolt log (`.jules/bolt.md`) to document the N+1 fix guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf08912cf055c276fd90a02497891c6cd8633570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->