### PR TITLE
⚡ Bolt: Optimize get_business_metrics O(N) traversals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2026-03-04 - Optimize WebSocket Metrics Gathering
 **Learning:** In `_get_business_metrics_sync` (used heavily by periodic websocket connections), multiple `func.sum(case(...))` clauses within a single SQLAlchemy `.query()` can be slow and put unnecessary load on the DB engine due to table scanning. It's an anti-pattern when pulling segmented aggregates.
 **Action:** When gathering status counts across an entire associated table, use a much more efficient `GROUP BY` query (`group_by(AgentTask.status)`) combined with a simple Python iteration mapping the output. This greatly mitigates event loop blocking risks from synchronous IO delays under load.
+## 2025-06-15 - Optimize get_business_metrics for RD Labs
+**Learning:** Found multiple O(N) list comprehensions iterating over the same collections in `get_business_metrics` methods in `magic_rd_lab.py` and `qulab_rental_business.py` causing redundant traversals.
+**Action:** Replaced multiple list comprehensions with a single O(N) `for` loop to reduce event loop blocking and memory allocations when gathering dashboard metrics.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,3 +1,7 @@
-🎯 **What:** Adds unit tests for the asynchronous `run_autonomous_loop` and `launch_magic_rd_lab_business` functions in `magic_rd_lab_autonomous_agents.py`. The infinite loop and sleeping functionality are mocked to allow fast, deterministic tests without running into timeout issues.
-📊 **Coverage:** Covered loop entry, loop exit conditions via mocked exceptions, agent deployments, invocation of underlying methods, and ensuring metrics sum exactly appropriately after 1 pass through the loop.
-✨ **Result:** Enhanced test coverage that protects core async loop functionality from regressions.
+💡 What: Replaced multiple list comprehensions and sequential loops in the `get_business_metrics` methods of `magic_rd_lab.py` and `qulab_rental_business.py` with single O(N) loops.
+
+🎯 Why: The original implementations iterated over the same unbounded collections (`self.sessions`, `self.customers`, `self.jobs`) multiple times to calculate different metrics (like active sessions, completed sessions, and package/tier distributions). This caused redundant memory allocations and event loop blocking, which scales poorly as the number of items grows.
+
+📊 Impact: Reduces computational complexity from O(k*N) to O(N) where k is the number of distinct metrics being gathered, and prevents unnecessary list creation/destruction in memory.
+
+🔬 Measurement: Verify changes via tests (`pytest tests/test_magic_rd_lab.py`) and by executing the direct scripts (`python3 src/blank_business_builder/magic_rd_lab.py` and `python3 src/blank_business_builder/qulab_rental_business.py`) to ensure no regressions occur.

--- a/src/blank_business_builder/magic_rd_lab.py
+++ b/src/blank_business_builder/magic_rd_lab.py
@@ -347,24 +347,34 @@ class MagicRDLab:
 
     def get_business_metrics(self) -> Dict[str, Any]:
         """Get business performance metrics."""
-        active_sessions = [s for s in self.sessions if s.status == "active"]
-        completed_sessions = [s for s in self.sessions if s.status == "completed"]
+        active_sessions_count = 0
+        completed_sessions_count = 0
+        total_computations = 0
 
         # Package distribution
-        package_dist = {}
-        for package in RentalPackage:
-            count = len([s for s in self.sessions if s.package == package])
-            package_dist[package.value] = count
+        package_dist = {package.value: 0 for package in RentalPackage}
+
+        # ⚡ Bolt Optimization: Calculate totals in a single O(N) pass
+        for s in self.sessions:
+            if s.status == "active":
+                active_sessions_count += 1
+            elif s.status == "completed":
+                completed_sessions_count += 1
+
+            if s.package.value in package_dist:
+                package_dist[s.package.value] += 1
+
+            total_computations += len(s.results)
 
         return {
             "total_revenue": float(self.revenue),
             "total_customers": len(self.customers),
             "total_sessions": len(self.sessions),
-            "active_sessions": len(active_sessions),
-            "completed_sessions": len(completed_sessions),
+            "active_sessions": active_sessions_count,
+            "completed_sessions": completed_sessions_count,
             "package_distribution": package_dist,
             "avg_revenue_per_customer": float(self.revenue / max(1, len(self.customers))),
-            "total_computations": sum(len(s.results) for s in self.sessions)
+            "total_computations": total_computations
         }
 
 

--- a/src/blank_business_builder/qulab_rental_business.py
+++ b/src/blank_business_builder/qulab_rental_business.py
@@ -504,15 +504,26 @@ class QuLabRentalBusiness:
 
     def get_business_metrics(self) -> Dict[str, Any]:
         """Get overall business metrics."""
+        # ⚡ Bolt Optimization: Calculate totals in a single O(N) pass
+        active_customers = 0
+        tier_distribution = {tier.value: 0 for tier in SubscriptionTier}
+        for c in self.customers.values():
+            if c.subscription_status == "active":
+                active_customers += 1
+            if c.tier.value in tier_distribution:
+                tier_distribution[c.tier.value] += 1
+
+        completed_jobs = 0
+        for j in self.jobs:
+            if j.status == "completed":
+                completed_jobs += 1
+
         return {
             "total_customers": len(self.customers),
-            "active_customers": len([c for c in self.customers.values() if c.subscription_status == "active"]),
-            "tier_distribution": {
-                tier.value: len([c for c in self.customers.values() if c.tier == tier])
-                for tier in SubscriptionTier
-            },
+            "active_customers": active_customers,
+            "tier_distribution": tier_distribution,
             "total_jobs": len(self.jobs),
-            "completed_jobs": len([j for j in self.jobs if j.status == "completed"]),
+            "completed_jobs": completed_jobs,
             "total_qubit_hours": self.total_qubit_hours,
             "total_revenue": float(self.revenue),
             "avg_revenue_per_customer": float(self.revenue / max(1, len(self.customers))),


### PR DESCRIPTION
💡 What: Replaced multiple list comprehensions and sequential loops in the `get_business_metrics` methods of `magic_rd_lab.py` and `qulab_rental_business.py` with single O(N) loops.

🎯 Why: The original implementations iterated over the same unbounded collections (`self.sessions`, `self.customers`, `self.jobs`) multiple times to calculate different metrics (like active sessions, completed sessions, and package/tier distributions). This caused redundant memory allocations and event loop blocking, which scales poorly as the number of items grows.

📊 Impact: Reduces computational complexity from O(k*N) to O(N) where k is the number of distinct metrics being gathered, and prevents unnecessary list creation/destruction in memory.

🔬 Measurement: Verified changes via tests (`pytest tests/test_magic_rd_lab.py`) and by executing the direct scripts (`python3 src/blank_business_builder/magic_rd_lab.py` and `python3 src/blank_business_builder/qulab_rental_business.py`) to ensure no regressions occurred.

---
*PR created automatically by Jules for task [15630446601711787500](https://jules.google.com/task/15630446601711787500) started by @Workofarttattoo*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors metric aggregation loops to be single-pass without changing external interfaces; primary risk is off-by-one/logic drift in counts and distributions.
> 
> **Overview**
> Speeds up dashboard metric collection by refactoring `get_business_metrics` in `magic_rd_lab.py` and `qulab_rental_business.py` to compute counts, distributions, and totals in **single O(N) passes** instead of multiple list comprehensions over the same collections.
> 
> Updates `.jules/bolt.md` and the PR body notes to document the optimization and its motivation (reducing event-loop blocking and allocations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5d787b9750cae9fc9fc52ab36fefa30a95b0c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->